### PR TITLE
Enhance keyword extraction with case sensitivity and disambiguation

### DIFF
--- a/agents/prompts/tech_extraction.md
+++ b/agents/prompts/tech_extraction.md
@@ -24,7 +24,15 @@ Return ONLY technologies from this list:
    - Soft skills or methodologies
    - Company or product names that are not technologies
 
-4. If the description provides no technical signal (or is empty), return {"technologies": []}.
+4. Some terms have non-technical meanings. Only include them when they are clearly used as a technology:
+   - **Go** → only the programming language. Not: "go-to solution", "let's go", "go ahead"
+   - **Python** → only the programming language. Not: "python snake", "Monty Python"
+   - **Java** → only the programming language. Not: "java coffee", "Java island"
+   - **REST** → only the REST architectural style (REST API, RESTful). Not: "rest period", "rest of the time", "take a rest"
+   - **RAG** → only Retrieval-Augmented Generation. Not: "rags", "rag content"
+   - **SAP** → only the ERP software. Not: "life sap", "maple sap"
+
+5. If the description provides no technical signal (or is empty), return {"technologies": []}.
 
 ## Output format
 

--- a/pipeline/extractor.py
+++ b/pipeline/extractor.py
@@ -112,13 +112,15 @@ def _collect_keywords(kw_element: etree._Element | None, job_data: dict) -> list
     if kw_element is None:
         return []
     sources = [s.strip() for s in kw_element.get("sources", "").split(",")]
-    flags = re.IGNORECASE if kw_element.get("case_insensitive") == "true" else 0
+    global_flags = re.IGNORECASE if kw_element.get("case_insensitive") == "true" else 0
     text = " ".join(str(job_data.get(s) or "") for s in sources)
-    return [
-        kw.get("canonical") or kw.text.strip()
-        for kw in kw_element.findall("kw")
-        if re.search(kw.text.strip(), text, flags)
-    ]
+    results = []
+    for kw in kw_element.findall("kw"):
+        # case_sensitive="true" on a <kw> overrides the element-level case_insensitive flag.
+        flags = 0 if kw.get("case_sensitive") == "true" else global_flags
+        if re.search(kw.text.strip(), text, flags):
+            results.append(kw.get("canonical") or kw.text.strip())
+    return results
 
 
 # ─── Extractor ───────────────────────────────────────────────────────────────

--- a/specs/greenhouse/extraction.xml
+++ b/specs/greenhouse/extraction.xml
@@ -92,7 +92,7 @@
         <kw canonical="Python">Python</kw>
         <kw canonical="JavaScript">JavaScript</kw>
         <kw canonical="TypeScript">TypeScript</kw>
-        <kw canonical="Go">(?:Go|Golang)</kw>
+        <kw canonical="Go" case_sensitive="true">(?:Go|Golang)</kw>
         <kw canonical="Rust">Rust</kw>
         <kw canonical="Java">Java</kw>
         <kw canonical="Kotlin">Kotlin</kw>
@@ -104,7 +104,7 @@
         <kw canonical="Swift">Swift</kw>
         <kw canonical="Elixir">Elixir</kw>
         <kw canonical="Erlang">Erlang</kw>
-        <kw canonical="R">\bR\b</kw>
+        <kw canonical="R" case_sensitive="true">\bR\b</kw>
 
         <!-- Frontend / Web -->
         <kw canonical="React">React</kw>
@@ -115,7 +115,7 @@
         <kw canonical="Node.js">Node(?:\.js)?</kw>
         <kw canonical="Express">Express</kw>
         <kw canonical="GraphQL">GraphQL</kw>
-        <kw canonical="REST">REST(?:ful)?</kw>
+        <kw canonical="REST" case_sensitive="true">REST(?:ful)?</kw>
 
         <!-- Backend frameworks -->
         <kw canonical="Django">Django</kw>
@@ -137,8 +137,8 @@
         <kw canonical="PyTorch">PyTorch</kw>
         <kw canonical="TensorFlow">TensorFlow</kw>
         <kw canonical="scikit-learn">scikit-learn</kw>
-        <kw canonical="LLM">LLM</kw>
-        <kw canonical="RAG">RAG</kw>
+        <kw canonical="LLM" case_sensitive="true">LLM</kw>
+        <kw canonical="RAG" case_sensitive="true">RAG</kw>
         <kw canonical="Flink">(?:Apache )?Flink</kw>
 
         <!-- Infrastructure / Cloud -->


### PR DESCRIPTION
**Title:** `fix: eliminate ambiguous-keyword false positives in both extraction paths`

**Summary:**
This PR addresses false positives caused by ambiguous tech keywords with non-technical meanings. It implements two complementary solutions:

1. **Regex Path (extraction.xml + extractor.py):**
   - Adds per-keyword `case_sensitive` attribute support to keyword matching
   - Marks `Go`, `R`, `REST`, `RAG`, and `LLM` as case-sensitive so only uppercase forms match (their lowercase versions are never the technology)
   - Modifies `_collect_keywords()` to respect per-keyword case sensitivity rules

2. **LLM Path (tech_extraction.md):**
   - Adds disambiguation rule with explicit counter-examples for ambiguous terms:
     - **Go** → not "go-to solution", "let's go", "go ahead"
     - **Python** → not "python snake", "Monty Python"
     - **Java** → not "java coffee", "Java island"
     - **REST** → not "rest period", "rest of the time", "take a rest"
     - **RAG** → not "rags", "rag content"
     - **SAP** → not "life sap", "maple sap"
   - Prompt hash change triggers re-enrichment of existing jobs on next enricher run

**Files Changed:** 3 files (22 additions, 12 deletions)
- `agents/prompts/tech_extraction.md`
- `pipeline/extractor.py`
- `specs/greenhouse/extraction.xml`