### PR TITLE
feat(frontend): redesign to minimal SaaS dashboard

### DIFF
--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  unstable_retry,
+}: {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center py-24 text-center">
+      <p className="text-sm font-medium text-zinc-950">Something went wrong.</p>
+      <p className="mt-1 text-sm text-zinc-400">
+        Could not load jobs. Check your connection or try again.
+      </p>
+      <button
+        onClick={unstable_retry}
+        className="mt-4 rounded-md border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors hover:border-blue-200 hover:text-blue-600"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8fafc;
-  --foreground: #0f172a;
+  --background: #fafafa;
+  --foreground: #09090b;
 }
 
 @theme inline {
@@ -15,5 +15,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), system-ui, sans-serif;
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -13,8 +14,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Jobs Radar QC — Tech jobs in Québec",
-  description: "Active tech job postings from Montreal and Quebec startups, updated daily.",
+  title: "Jobs Radar QC — The Quebec tech job market, indexed daily.",
+  description:
+    "Active tech job postings from Montreal and Quebec companies, tracked directly from Greenhouse, Lever, and Workable. Updated daily.",
 };
 
 export default function RootLayout({
@@ -27,7 +29,35 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col bg-slate-50">{children}</body>
+      <body className="flex min-h-full flex-col bg-zinc-50 text-zinc-950">
+        <nav className="border-b border-zinc-200 bg-white">
+          <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
+            <Link
+              href="/"
+              className="text-sm font-semibold text-zinc-950 transition-colors hover:text-blue-600"
+            >
+              Jobs Radar QC
+            </Link>
+            <div className="flex items-center gap-5">
+              <Link
+                href="/trends"
+                className="text-sm text-zinc-500 transition-colors hover:text-zinc-950"
+              >
+                Tech Radar
+              </Link>
+              <a
+                href="https://github.com/hippync/jobs-radar-qc"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-zinc-500 transition-colors hover:text-zinc-950"
+              >
+                GitHub ↗
+              </a>
+            </div>
+          </div>
+        </nav>
+        {children}
+      </body>
     </html>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import { Job } from "@/lib/types";
 import JobCard from "@/components/JobCard";
@@ -17,7 +18,7 @@ interface SearchParams {
 async function fetchJobs(filters: SearchParams): Promise<{ jobs: Job[]; total: number }> {
   const page = Math.max(1, parseInt(filters.page ?? "1", 10));
   const from = (page - 1) * PAGE_SIZE;
-  const to = from + PAGE_SIZE - 1;
+  const to   = from + PAGE_SIZE - 1;
 
   let query = supabase
     .from("active_qc_jobs")
@@ -38,17 +39,30 @@ async function fetchJobs(filters: SearchParams): Promise<{ jobs: Job[]; total: n
   return { jobs: (data ?? []) as Job[], total: count ?? 0 };
 }
 
-async function fetchFilterOptions(): Promise<{ techOptions: string[]; sourceOptions: string[] }> {
-  const { data } = await supabase.from("active_qc_jobs").select("tech_stack, source");
+async function fetchStats(): Promise<{
+  techOptions: string[];
+  sourceOptions: string[];
+  companyCount: number;
+}> {
+  const { data } = await supabase
+    .from("active_qc_jobs")
+    .select("tech_stack, source, company");
 
-  const techSet = new Set<string>();
-  const sourceSet = new Set<string>();
+  const techSet    = new Set<string>();
+  const sourceSet  = new Set<string>();
+  const companySet = new Set<string>();
+
   for (const row of data ?? []) {
     for (const t of row.tech_stack ?? []) techSet.add(t);
-    if (row.source) sourceSet.add(row.source);
+    if (row.source)  sourceSet.add(row.source);
+    if (row.company) companySet.add(row.company);
   }
 
-  return { techOptions: [...techSet].sort(), sourceOptions: [...sourceSet].sort() };
+  return {
+    techOptions:  [...techSet].sort(),
+    sourceOptions: [...sourceSet].sort(),
+    companyCount: companySet.size,
+  };
 }
 
 export default async function Page({
@@ -57,14 +71,13 @@ export default async function Page({
   searchParams: Promise<SearchParams>;
 }) {
   const filters = await searchParams;
-  const page = Math.max(1, parseInt(filters.page ?? "1", 10));
+  const page    = Math.max(1, parseInt(filters.page ?? "1", 10));
 
-  const [{ jobs, total }, { techOptions, sourceOptions }] = await Promise.all([
-    fetchJobs(filters),
-    fetchFilterOptions(),
-  ]);
+  const [{ jobs, total }, { techOptions, sourceOptions, companyCount }] =
+    await Promise.all([fetchJobs(filters), fetchStats()]);
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
+  const hasFilters = !!(filters.tech || filters.source || filters.remote || filters.seniority);
 
   function pageUrl(p: number) {
     const q = new URLSearchParams();
@@ -77,42 +90,40 @@ export default async function Page({
     return qs ? `?${qs}` : "/";
   }
 
-  const hasFilters = !!(filters.tech || filters.source || filters.remote || filters.seniority);
-
   return (
     <>
-      {/* Hero header */}
-      <header className="bg-gradient-to-br from-violet-700 to-violet-900">
-        <div className="mx-auto max-w-5xl px-4 py-10">
-          <h1 className="text-3xl font-bold tracking-tight text-white">
-            Jobs Radar QC
+      {/* Page header */}
+      <header className="border-b border-zinc-200 bg-white">
+        <div className="mx-auto max-w-5xl px-4 py-8">
+          <h1 className="text-2xl font-semibold tracking-tight text-zinc-950">
+            The Quebec tech job market, indexed daily.
           </h1>
-          <p className="mt-1 text-sm text-violet-200">
-            Active tech jobs in Québec — updated daily from Greenhouse, Lever &amp; Workable.
+          <p className="mt-1.5 max-w-xl text-sm text-zinc-500">
+            Track what Quebec tech companies are hiring for — directly from Greenhouse, Lever,
+            and Workable ATS pages. No aggregators, no sponsored posts.
           </p>
-          <div className="mt-4 flex items-center gap-3">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-400/20 px-3 py-1 text-xs font-semibold text-amber-200 ring-1 ring-amber-300/30">
-              <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-              {total} active job{total !== 1 ? "s" : ""}
+
+          {/* Stats row */}
+          <div className="mt-5 flex flex-wrap items-center gap-x-6 gap-y-2 border-t border-zinc-100 pt-4 text-sm text-zinc-500">
+            <span>
+              <span className="font-semibold text-zinc-950">{total}</span>{" "}
+              {hasFilters ? "matching" : "active"} role{total !== 1 ? "s" : ""}
             </span>
-            {hasFilters && (
-              <span className="text-xs text-violet-300">
-                filtered
-              </span>
-            )}
-            <a
-              href="/trends"
-              className="inline-flex items-center gap-1 rounded-full bg-violet-600/40 px-3 py-1 text-xs font-medium text-violet-200 ring-1 ring-violet-400/30 transition hover:bg-violet-600/60 hover:text-white"
-            >
-              Tech Radar →
-            </a>
+            <span>
+              <span className="font-semibold text-zinc-950">{companyCount}</span>{" "}
+              companies tracked
+            </span>
+            <span>
+              <span className="font-semibold text-zinc-950">3</span>{" "}
+              ATS platforms
+            </span>
           </div>
         </div>
       </header>
 
       {/* Sticky filter bar */}
-      <div className="sticky top-0 z-10 border-b border-slate-200 bg-white shadow-sm">
-        <div className="mx-auto max-w-5xl px-4 py-3">
+      <div className="sticky top-0 z-10 border-b border-zinc-200 bg-white/95 backdrop-blur-sm">
+        <div className="mx-auto max-w-5xl px-4 py-2.5">
           <Suspense>
             <JobFilters techOptions={techOptions} sourceOptions={sourceOptions} />
           </Suspense>
@@ -120,20 +131,24 @@ export default async function Page({
       </div>
 
       {/* Main content */}
-      <main className="mx-auto w-full max-w-5xl px-4 py-6">
-        <p className="mb-4 text-sm text-slate-500">
-          <span className="font-semibold text-violet-700">{total}</span>{" "}
-          job{total !== 1 ? "s" : ""}
-          {filters.tech && (
-            <> with <span className="font-medium text-slate-700">{filters.tech}</span></>
-          )}
-          {filters.seniority && (
-            <> · <span className="font-medium text-slate-700">{filters.seniority}</span></>
-          )}
-        </p>
-
+      <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-6">
         {jobs.length === 0 ? (
-          <p className="py-20 text-center text-slate-400">No jobs match your filters.</p>
+          <div className="flex flex-col items-center py-24 text-center">
+            <p className="text-sm font-medium text-zinc-950">
+              No jobs match these filters.
+            </p>
+            <p className="mt-1 text-sm text-zinc-400">
+              Try clearing filters or check back after the next daily fetch.
+            </p>
+            {hasFilters && (
+              <Link
+                href="/"
+                className="mt-4 rounded-md border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors hover:border-blue-200 hover:text-blue-600"
+              >
+                Clear filters
+              </Link>
+            )}
+          </div>
         ) : (
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {jobs.map((job) => (
@@ -142,40 +157,45 @@ export default async function Page({
           </div>
         )}
 
+        {/* Pagination */}
         {totalPages > 1 && (
           <div className="mt-10 flex items-center justify-center gap-3">
             {page > 1 && (
               <a
                 href={pageUrl(page - 1)}
-                className="rounded-lg border border-slate-200 px-4 py-2 text-sm text-slate-600 transition hover:border-violet-300 hover:text-violet-700"
+                className="rounded-md border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors hover:border-blue-200 hover:text-blue-600"
               >
                 ← Prev
               </a>
             )}
-            <span className="text-sm text-slate-400">{page} / {totalPages}</span>
+            <span className="text-sm tabular-nums text-zinc-400">
+              {page} / {totalPages}
+            </span>
             {page < totalPages && (
               <a
                 href={pageUrl(page + 1)}
-                className="rounded-lg border border-slate-200 px-4 py-2 text-sm text-slate-600 transition hover:border-violet-300 hover:text-violet-700"
+                className="rounded-md border border-zinc-200 px-4 py-2 text-sm text-zinc-600 transition-colors hover:border-blue-200 hover:text-blue-600"
               >
                 Next →
               </a>
             )}
           </div>
         )}
+      </main>
 
-        <p className="mt-12 text-center text-xs text-slate-300">
+      <footer className="border-t border-zinc-100 py-6">
+        <p className="text-center text-xs text-zinc-400">
           Open source ·{" "}
           <a
             href="https://github.com/hippync/jobs-radar-qc"
             target="_blank"
             rel="noopener noreferrer"
-            className="hover:text-violet-400"
+            className="transition-colors hover:text-blue-500"
           >
             github.com/hippync/jobs-radar-qc
           </a>
         </p>
-      </main>
+      </footer>
     </>
   );
 }

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import React from "react";
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 
@@ -46,76 +47,95 @@ export default async function TrendsPage() {
 
   return (
     <>
-      <header className="bg-gradient-to-br from-violet-700 to-violet-900">
-        <div className="mx-auto max-w-5xl px-4 py-10">
-          <nav className="mb-4 text-sm">
-            <Link href="/" className="text-violet-300 hover:text-white transition">
-              ← Back to jobs
+      <header className="border-b border-zinc-200 bg-white">
+        <div className="mx-auto max-w-2xl px-4 py-8">
+          <nav className="mb-3">
+            <Link
+              href="/"
+              className="text-sm text-zinc-400 transition-colors hover:text-zinc-950"
+            >
+              ← Jobs
             </Link>
           </nav>
-          <h1 className="text-3xl font-bold tracking-tight text-white">
+          <h1 className="text-2xl font-semibold tracking-tight text-zinc-950">
             Tech Stack Radar
           </h1>
-          <p className="mt-1 text-sm text-violet-200">
-            Most in-demand technologies across {jobCount} active QC tech jobs.
+          <p className="mt-1.5 text-sm text-zinc-500">
+            How many active QC tech roles list each technology. Click a row to filter jobs.
+            Updated daily.
+          </p>
+          <p className="mt-3 text-sm text-zinc-400">
+            <span className="font-medium text-zinc-700">{jobCount}</span> active roles indexed
           </p>
         </div>
       </header>
 
-      <main className="mx-auto w-full max-w-2xl px-4 py-10">
+      <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-8">
         {techs.length === 0 ? (
-          <div className="rounded-xl border border-slate-200 bg-white p-12 text-center shadow-sm">
-            <p className="text-slate-500 font-medium">Data accumulating</p>
-            <p className="mt-1 text-sm text-slate-400">
+          <div className="rounded-lg border border-zinc-200 bg-white p-12 text-center">
+            <p className="text-sm font-medium text-zinc-950">Data accumulating</p>
+            <p className="mt-1 text-sm text-zinc-400">
               Check back once the daily pipeline has run a few times.
             </p>
           </div>
         ) : (
-          <div className="rounded-xl border border-slate-200 bg-white shadow-sm overflow-hidden">
-            <div className="px-6 py-4 border-b border-slate-100 flex items-center justify-between">
-              <h2 className="text-sm font-semibold text-slate-700">
+          <div className="overflow-hidden rounded-lg border border-zinc-200 bg-white">
+            {/* Table header */}
+            <div className="flex items-center justify-between border-b border-zinc-100 px-5 py-3.5">
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
                 Top {techs.length} technologies
               </h2>
-              <span className="text-xs text-slate-400">
-                {jobCount} active roles · click to filter
-              </span>
+              <span className="text-xs text-zinc-400">roles · click to filter</span>
             </div>
 
-            <div className="px-6 py-5 space-y-3.5">
+            {/* Rows */}
+            <div className="divide-y divide-zinc-50">
               {techs.map(({ tech, count }, i) => (
-                <a
-                  key={tech}
-                  href={`/?tech=${encodeURIComponent(tech)}`}
-                  className="flex items-center gap-3 group"
-                >
-                  {/* Rank */}
-                  <span className="w-5 shrink-0 text-right text-xs text-slate-300">
-                    {i + 1}
-                  </span>
+                <React.Fragment key={tech}>
+                  {/* Tier break after top 5 */}
+                  {i === 5 && (
+                    <div className="border-t border-zinc-200 bg-zinc-50 px-5 py-1.5">
+                      <span className="text-xs font-medium text-zinc-400">Emerging</span>
+                    </div>
+                  )}
+                  <a
+                    href={`/?tech=${encodeURIComponent(tech)}`}
+                    className="group flex items-center gap-4 px-5 py-3 transition-colors hover:bg-zinc-50"
+                  >
+                    {/* Rank */}
+                    <span className="w-5 shrink-0 text-right text-xs tabular-nums text-zinc-300">
+                      {i + 1}
+                    </span>
 
-                  {/* Tech name */}
-                  <span className="w-28 shrink-0 truncate text-sm font-medium text-slate-700 group-hover:text-violet-600 transition">
-                    {tech}
-                  </span>
+                    {/* Tech name */}
+                    <span className="w-28 shrink-0 truncate text-sm font-medium text-zinc-800 transition-colors group-hover:text-blue-600">
+                      {tech}
+                    </span>
 
-                  {/* Bar */}
-                  <div className="flex-1 overflow-hidden rounded-full bg-slate-100 h-2">
-                    <div
-                      className="h-2 rounded-full bg-violet-400 group-hover:bg-violet-500 transition-colors"
-                      style={{ width: `${(count / maxCount) * 100}%` }}
-                    />
-                  </div>
+                    {/* Bar */}
+                    <div className="flex-1 overflow-hidden rounded-full bg-zinc-100 h-1.5">
+                      <div
+                        className={`h-1.5 rounded-full transition-colors ${
+                          i < 5
+                            ? "bg-blue-500 group-hover:bg-blue-600"
+                            : "bg-blue-300 group-hover:bg-blue-400"
+                        }`}
+                        style={{ width: `${(count / maxCount) * 100}%` }}
+                      />
+                    </div>
 
-                  {/* Count */}
-                  <span className="w-8 shrink-0 text-right text-sm font-semibold text-slate-600">
-                    {count}
-                  </span>
-                </a>
+                    {/* Count */}
+                    <span className="w-8 shrink-0 text-right text-sm tabular-nums text-zinc-500">
+                      {count}
+                    </span>
+                  </a>
+                </React.Fragment>
               ))}
             </div>
 
-            <div className="px-6 py-3 border-t border-slate-100 bg-slate-50">
-              <p className="text-xs text-slate-400">
+            {/* Footer note */}
+            <div className="border-t border-zinc-100 bg-zinc-50 px-5 py-3">
+              <p className="text-xs text-zinc-400">
                 Includes rule-based and LLM-enriched tech stacks. Counts reflect active
                 jobs only — closed postings are excluded.
               </p>
@@ -123,6 +143,20 @@ export default async function TrendsPage() {
           </div>
         )}
       </main>
+
+      <footer className="border-t border-zinc-100 py-6">
+        <p className="text-center text-xs text-zinc-400">
+          Open source ·{" "}
+          <a
+            href="https://github.com/hippync/jobs-radar-qc"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-blue-500"
+          >
+            github.com/hippync/jobs-radar-qc
+          </a>
+        </p>
+      </footer>
     </>
   );
 }

--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -1,20 +1,21 @@
 import { Job } from "@/lib/types";
+import SourceBadge from "./SourceBadge";
 
-const SENIORITY_BADGE: Record<string, string> = {
-  internship: "bg-amber-50 text-amber-600 ring-1 ring-amber-200",
-  junior:     "bg-amber-100 text-amber-700 ring-1 ring-amber-200",
-  senior:     "bg-violet-100 text-violet-700 ring-1 ring-violet-200",
-  lead:       "bg-violet-100 text-violet-800 ring-1 ring-violet-200",
-  staff:      "bg-violet-200 text-violet-900 ring-1 ring-violet-300",
-  principal:  "bg-violet-200 text-violet-900 ring-1 ring-violet-300",
-  manager:    "bg-slate-100 text-slate-700 ring-1 ring-slate-200",
-  director:   "bg-slate-100 text-slate-800 ring-1 ring-slate-200",
+const SENIORITY_LABEL: Record<string, string> = {
+  internship: "Intern",
+  junior:     "Junior",
+  senior:     "Senior",
+  lead:       "Lead",
+  staff:      "Staff",
+  principal:  "Principal",
+  manager:    "Manager",
+  director:   "Director",
 };
 
-function remoteLabel(is_remote: boolean | null) {
-  if (is_remote === true)  return { label: "Remote",  cls: "bg-emerald-100 text-emerald-700 ring-1 ring-emerald-200" };
-  if (is_remote === false) return { label: "On-site", cls: "bg-slate-100 text-slate-600 ring-1 ring-slate-200" };
-  return                          { label: "Hybrid",  cls: "bg-amber-100 text-amber-700 ring-1 ring-amber-200" };
+function remoteLabel(is_remote: boolean | null): string {
+  if (is_remote === true)  return "Remote";
+  if (is_remote === false) return "On-site";
+  return "Hybrid";
 }
 
 function age(iso: string | null): { text: string; fresh: boolean } {
@@ -22,13 +23,10 @@ function age(iso: string | null): { text: string; fresh: boolean } {
   const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000);
   if (diff === 0) return { text: "today",     fresh: true };
   if (diff === 1) return { text: "yesterday", fresh: true };
-  if (diff <= 3)  return { text: `${diff}d ago`, fresh: true };
-  return                 { text: `${diff}d ago`, fresh: false };
+  return               { text: `${diff}d`,   fresh: false };
 }
 
 export default function JobCard({ job }: { job: Job }) {
-  const { label: remLabel, cls: remCls } = remoteLabel(job.is_remote);
-  const senCls = job.seniority ? SENIORITY_BADGE[job.seniority] ?? "bg-slate-100 text-slate-600" : null;
   const { text: ageText, fresh } = age(job.first_seen_at);
 
   return (
@@ -36,65 +34,67 @@ export default function JobCard({ job }: { job: Job }) {
       href={job.source_url}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition-all duration-150 hover:border-violet-300 hover:shadow-md hover:shadow-violet-100"
+      className="group flex flex-col rounded-lg border border-zinc-200 border-l-2 border-l-zinc-200 bg-white p-4 transition-all hover:border-zinc-300 hover:border-l-blue-500 hover:shadow-sm"
     >
-      {/* Top row */}
+      {/* Company + age */}
       <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-wide text-violet-600">
-            {job.company}
-          </p>
-          <h2 className="mt-0.5 line-clamp-2 text-sm font-semibold text-slate-900 group-hover:text-violet-700">
-            {job.title}
-          </h2>
-          {job.location && (
-            <p className="mt-0.5 truncate text-xs text-slate-400">{job.location}</p>
-          )}
-        </div>
+        <p className="text-xs font-medium uppercase tracking-wide text-zinc-400">
+          {job.company}
+        </p>
         {ageText && (
           <span
-            className={`shrink-0 text-xs font-medium ${
-              fresh ? "text-emerald-500" : "text-slate-300"
+            className={`shrink-0 text-xs ${
+              fresh ? "font-medium text-blue-500" : "text-zinc-300"
             }`}
           >
-            {fresh && <span className="mr-1">●</span>}
-            {ageText}
+            {fresh && "● "}{ageText}
           </span>
         )}
       </div>
 
-      {/* Badges */}
-      <div className="mt-3 flex flex-wrap gap-1.5">
-        <span className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-medium ${remCls}`}>
-          {remLabel}
+      {/* Title */}
+      <h2 className="mt-1 line-clamp-2 text-sm font-semibold text-zinc-900 transition-colors group-hover:text-blue-600">
+        {job.title}
+      </h2>
+
+      {/* Location */}
+      {job.location && (
+        <p className="mt-0.5 truncate text-xs text-zinc-400">{job.location}</p>
+      )}
+
+      {/* Status badges */}
+      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+        <span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs text-zinc-500 ring-1 ring-zinc-200">
+          {remoteLabel(job.is_remote)}
         </span>
 
-        {senCls && (
-          <span className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-xs font-medium ${senCls}`}>
-            {job.seniority}
+        {job.seniority && SENIORITY_LABEL[job.seniority] && (
+          <span className="inline-flex items-center rounded px-1.5 py-0.5 text-xs text-zinc-500 ring-1 ring-zinc-200">
+            {SENIORITY_LABEL[job.seniority]}
           </span>
         )}
 
-        {job.employment_type && (
-          <span className="inline-flex items-center rounded-md bg-slate-100 px-1.5 py-0.5 text-xs text-slate-500 ring-1 ring-slate-200">
-            {job.employment_type}
-          </span>
-        )}
-
-        {job.tech_stack.slice(0, 4).map((t) => (
-          <span
-            key={t}
-            className="inline-flex items-center rounded-md bg-violet-50 px-1.5 py-0.5 text-xs font-medium text-violet-600 ring-1 ring-violet-200"
-          >
-            {t}
-          </span>
-        ))}
-        {job.tech_stack.length > 4 && (
-          <span className="self-center text-xs text-slate-300">
-            +{job.tech_stack.length - 4}
-          </span>
-        )}
+        <SourceBadge source={job.source} />
       </div>
+
+      {/* Tech chips */}
+      {job.tech_stack.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {job.tech_stack.slice(0, 4).map((t) => (
+            <span
+              key={t}
+              className="inline-flex items-center rounded bg-zinc-50 px-1.5 py-0.5 text-xs font-medium text-zinc-600 ring-1 ring-zinc-200"
+            >
+              {t}
+            </span>
+          ))}
+          {job.tech_stack.length > 4 && (
+            <span className="self-center text-xs text-zinc-300">
+              +{job.tech_stack.length - 4}
+            </span>
+          )}
+        </div>
+      )}
     </a>
   );
 }

--- a/frontend/components/JobFilters.tsx
+++ b/frontend/components/JobFilters.tsx
@@ -8,10 +8,15 @@ interface Props {
   sourceOptions: string[];
 }
 
-const SELECT_CLS =
-  "rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm " +
-  "focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-100 " +
-  "transition hover:border-slate-300";
+const BASE_SELECT =
+  "rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-700 " +
+  "focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100 " +
+  "transition-colors hover:border-zinc-300";
+
+const ACTIVE_SELECT =
+  "rounded-md border border-blue-300 bg-blue-50 px-2.5 py-1.5 text-sm text-blue-700 " +
+  "focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100 " +
+  "transition-colors";
 
 export default function JobFilters({ techOptions, sourceOptions }: Props) {
   const router = useRouter();
@@ -33,27 +38,31 @@ export default function JobFilters({ techOptions, sourceOptions }: Props) {
   const hasFilters = !!(tech || source || remote || seniority);
 
   return (
-    <div className={`flex flex-wrap items-center gap-2 ${isPending ? "opacity-50 pointer-events-none" : ""}`}>
-      <select value={tech} onChange={(e) => update("tech", e.target.value)} className={SELECT_CLS}>
-        <option value="">All technologies</option>
-        {techOptions.map((t) => <option key={t} value={t}>{t}</option>)}
-      </select>
+    <div
+      className={`flex flex-nowrap items-center gap-2 overflow-x-auto ${
+        isPending ? "pointer-events-none opacity-50" : ""
+      }`}
+    >
+      <span className="shrink-0 text-xs font-medium text-zinc-400">Filter:</span>
 
-      <select value={source} onChange={(e) => update("source", e.target.value)} className={SELECT_CLS}>
-        <option value="">All sources</option>
-        {sourceOptions.map((s) => (
-          <option key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</option>
+      <select
+        value={tech}
+        onChange={(e) => update("tech", e.target.value)}
+        aria-label="Filter by technology"
+        className={tech ? ACTIVE_SELECT : BASE_SELECT}
+      >
+        <option value="">All technologies</option>
+        {techOptions.map((t) => (
+          <option key={t} value={t}>{t}</option>
         ))}
       </select>
 
-      <select value={remote} onChange={(e) => update("remote", e.target.value)} className={SELECT_CLS}>
-        <option value="">Any workplace</option>
-        <option value="true">Remote</option>
-        <option value="false">On-site</option>
-        <option value="null">Hybrid</option>
-      </select>
-
-      <select value={seniority} onChange={(e) => update("seniority", e.target.value)} className={SELECT_CLS}>
+      <select
+        value={seniority}
+        onChange={(e) => update("seniority", e.target.value)}
+        aria-label="Filter by seniority"
+        className={seniority ? ACTIVE_SELECT : BASE_SELECT}
+      >
         <option value="">All levels</option>
         <option value="internship">Internship</option>
         <option value="junior">Junior</option>
@@ -65,12 +74,38 @@ export default function JobFilters({ techOptions, sourceOptions }: Props) {
         <option value="director">Director</option>
       </select>
 
+      <select
+        value={remote}
+        onChange={(e) => update("remote", e.target.value)}
+        aria-label="Filter by workplace"
+        className={remote ? ACTIVE_SELECT : BASE_SELECT}
+      >
+        <option value="">Any workplace</option>
+        <option value="true">Remote</option>
+        <option value="false">On-site</option>
+        <option value="null">Hybrid</option>
+      </select>
+
+      <select
+        value={source}
+        onChange={(e) => update("source", e.target.value)}
+        aria-label="Filter by ATS source"
+        className={source ? ACTIVE_SELECT : BASE_SELECT}
+      >
+        <option value="">All sources</option>
+        {sourceOptions.map((s) => (
+          <option key={s} value={s}>
+            {s.charAt(0).toUpperCase() + s.slice(1)}
+          </option>
+        ))}
+      </select>
+
       {hasFilters && (
         <button
           onClick={() => startTransition(() => router.replace("/"))}
-          className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-400 transition hover:border-violet-300 hover:text-violet-600"
+          className="shrink-0 rounded-md border border-zinc-200 px-2.5 py-1.5 text-sm text-zinc-400 transition-colors hover:border-blue-200 hover:text-blue-600"
         >
-          Clear
+          × Clear
         </button>
       )}
     </div>

--- a/frontend/components/SourceBadge.tsx
+++ b/frontend/components/SourceBadge.tsx
@@ -1,0 +1,29 @@
+const SOURCE_STYLE: Record<string, { label: string; cls: string }> = {
+  greenhouse: {
+    label: "Greenhouse",
+    cls: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+  },
+  lever: {
+    label: "Lever",
+    cls: "bg-blue-50 text-blue-700 ring-blue-200",
+  },
+  workable: {
+    label: "Workable",
+    cls: "bg-orange-50 text-orange-700 ring-orange-200",
+  },
+};
+
+export default function SourceBadge({ source }: { source: string }) {
+  const style = SOURCE_STYLE[source] ?? {
+    label: source,
+    cls: "bg-zinc-100 text-zinc-600 ring-zinc-200",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ring-1 ${style.cls}`}
+    >
+      {style.label}
+    </span>
+  );
+}


### PR DESCRIPTION
- Fix Geist font override bug in globals.css
- Add persistent site nav in layout.tsx (Tech Radar + GitHub links)
- Homepage: flat white header, tagline, stats row, improved empty state
- New app/error.tsx error boundary (Next.js 16 unstable_retry)
- Trends: flat header, blue bars, top-5 vs emerging tier break
- JobCard: zinc palette, blue left-border accent on hover, SourceBadge
- JobFilters: active-filter blue highlight, mobile horizontal scroll, aria-labels
- New SourceBadge: Greenhouse green, Lever blue, Workable orange

lint clean, build clean, TypeScript clean