### PR TITLE
Add verified QC companies and fix location pattern extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Jobs Radar QC is an open-source, spec-driven job market radar that tracks Quebec tech roles directly from ATS platforms, extracts the technologies companies are hiring for, and visualizes stack demand over time.
 
-| 29 companies tracked | 73 canonical technologies | ~2M tokens/week | ~41% prompt cache hit rate |
+| 37 companies tracked | 73 canonical technologies | ~2M tokens/week | ~41% prompt cache hit rate |
 |---|---|---|---|
 | across 3 ATS platforms | in extraction stack | LLM enrichment volume | ~$2/week saved vs baseline |
 
@@ -30,7 +30,7 @@ Jobs Radar QC is an open-source, spec-driven job market radar that tracks Quebec
 ## Current coverage
 
 - 3 ATS platforms: Greenhouse, Lever, Workable
-- 29 Quebec tech companies tracked
+- 37 Quebec tech companies tracked
 - Daily automated fetch via GitHub Actions
 - Weekly LLM enrichment (Claude Haiku, Sundays)
 - 73 canonical technologies tracked
@@ -233,7 +233,7 @@ specs/
     source.md               # API docs, rate limits, known quirks
     schema.json             # Endpoint config + company list
     extraction.xml          # Field mappings + derivation rules
-  lever/                    # Plusgrade, Mirego, Osedea, Spiria, Behaviour Interactive, Wattpad
+  lever/                    # 14 QC companies (Plusgrade, Mirego, Osedea, Spiria, Behaviour Interactive, Wattpad, Kogniz, Xsolla, Mistral AI, Spreedly, Telesat, Swapcard, Kabam, TrackTik)
     source.md
     schema.json
     extraction.xml
@@ -275,7 +275,7 @@ frontend/                   # Next.js 16 — App Router
 | Component | Status |
 |---|---|
 | Greenhouse spec | ✅ Live — 14 QC companies |
-| Lever spec | ✅ Live — 6 QC companies |
+| Lever spec | ✅ Live — 14 QC companies |
 | Workable spec | ✅ Live — 9 QC companies |
 | Extraction pipeline | ✅ Live |
 | Supabase storage | ✅ Live |

--- a/specs/greenhouse/extraction.xml
+++ b/specs/greenhouse/extraction.xml
@@ -45,7 +45,7 @@
     <!-- is_qc: true when location mentions a Quebec city or region -->
     <field name="is_qc" type="bool" default="false">
       <match source="location"
-             pattern="(?i)(montr[eé]al|qu[eé]bec city|laval|longueuil|brossard|sherbrooke|gatineau|saint-jean|terrebonne|\bqc\b)"
+             pattern="(?i)(montr[eé]al|qu[eé]bec|laval|longueuil|brossard|sherbrooke|gatineau|saint-jean|terrebonne|\bqc\b)"
              value="true" />
     </field>
 

--- a/specs/lever/extraction.xml
+++ b/specs/lever/extraction.xml
@@ -46,7 +46,7 @@
 
     <field name="is_qc" type="bool" default="false">
       <match source="location"
-             pattern="(?i)(montr[eé]al|qu[eé]bec city|laval|longueuil|brossard|sherbrooke|gatineau|\bqc\b)"
+             pattern="(?i)(montr[eé]al|qu[eé]bec|laval|longueuil|brossard|sherbrooke|gatineau|\bqc\b)"
              value="true" />
     </field>
 

--- a/specs/lever/schema.json
+++ b/specs/lever/schema.json
@@ -20,7 +20,15 @@
     { "name": "Osedea",                 "slug": "osedea"    },
     { "name": "Spiria",                 "slug": "spiria"    },
     { "name": "Behaviour Interactive",  "slug": "bhvr"      },
-    { "name": "Wattpad",                "slug": "wattpad"   }
+    { "name": "Wattpad",                "slug": "wattpad"   },
+    { "name": "Kogniz",                 "slug": "kogniz"    },
+    { "name": "Xsolla",                 "slug": "xsolla"    },
+    { "name": "Mistral AI",             "slug": "mistral"   },
+    { "name": "Spreedly",               "slug": "spreedly"  },
+    { "name": "Telesat",                "slug": "telesat"   },
+    { "name": "Swapcard",               "slug": "swapcard"  },
+    { "name": "Kabam",                  "slug": "kabam"     },
+    { "name": "TrackTik",               "slug": "tracktik"  }
   ],
   "validation": {
     "required_fields": ["id", "text", "hostedUrl"],

--- a/specs/workable/extraction.xml
+++ b/specs/workable/extraction.xml
@@ -39,7 +39,7 @@
 
     <field name="is_qc" type="bool" default="false">
       <match source="location"
-             pattern="(?i)(montr[eé]al|qu[eé]bec city|laval|longueuil|brossard|sherbrooke|gatineau|\bqc\b)"
+             pattern="(?i)(montr[eé]al|qu[eé]bec|laval|longueuil|brossard|sherbrooke|gatineau|\bqc\b)"
              value="true" />
     </field>
 


### PR DESCRIPTION
Schema: verified each slug against the public Lever API (?mode=json). Checked location strings to confirm Montreal/QC primary locations.

New companies: Kogniz (Montreal), Xsolla (Montreal HQ), Mistral AI (Montreal office), Spreedly (Montreal, Quebec), Telesat (Gatineau + Montreal), Swapcard (Québec), Kabam (Montreal), TrackTik (Montreal).

Skipped: Plusgrade + OSEDEA already tracked; Potloc / Aviya / Trackforce all 404; Pelmorex only Oakville ON (no QC primary location).

Extraction fix (all 3 specs): qu[eé]bec city → qu[eé]bec — the old pattern missed standalone "Québec" location strings (Swapcard case). Backward-compatible: "Quebec City" still matches since it contains "québec".