### PR TITLE
fix: add word boundaries for Go keyword to prevent false positives in…

### DIFF
--- a/pipeline/extractor.py
+++ b/pipeline/extractor.py
@@ -124,21 +124,31 @@ def _with_word_boundary(pattern: str) -> str:
 
     Skips positions already guarded by an explicit \\b in the pattern string.
     Handles special-char tech names correctly:
-      - Java  → \\bJava\\b  (prevents matching inside "JavaScript")
-      - C\\+\\+ → \\bC\\+\\+  (suffix omitted: + is non-word, boundary there is implicit)
-      - \\.NET → \\.NET\\b  (prefix omitted: starts with \\, not a word char)
-      - \\bR\\b → unchanged  (already fully guarded)
+      - Java          → \\bJava\\b        (prevents matching inside "JavaScript")
+      - C\\+\\+       → \\bC\\+\\+        (suffix omitted: + is non-word, boundary implicit)
+      - \\.NET        → \\.NET\\b         (prefix omitted: starts with \\, not a word char)
+      - \\bR\\b       → unchanged          (already fully guarded)
+      - (?:Go|Golang) → \\b(?:Go|Golang)\\b (peeks inside leading (?:, trailing ))
     """
     if not pattern:
         return pattern
+    # For patterns that start with a non-capturing group (?:...), peek at the
+    # first character inside the group rather than the literal '(' character.
+    effective_first = (
+        pattern[3] if pattern.startswith(r"(?:") and len(pattern) > 3 else pattern[0]
+    )
     prefix = (
         r"\b"
-        if not pattern.startswith(r"\b") and re.match(r"[A-Za-z0-9_]", pattern[0])
+        if not pattern.startswith(r"\b") and re.match(r"[A-Za-z0-9_]", effective_first)
         else ""
     )
+    # For patterns that end with a quantified closing paren — e.g. (?:ful)? or
+    # (?:\.js)? — find the last word character inside the group rather than ')'.
+    trailing = re.search(r"([A-Za-z0-9_])\)[?*+]?(?:\{[^}]*\})?$", pattern)
+    effective_last = trailing.group(1) if trailing else pattern[-1]
     suffix = (
         r"\b"
-        if not pattern.endswith(r"\b") and re.match(r"[A-Za-z0-9_]", pattern[-1])
+        if not pattern.endswith(r"\b") and re.match(r"[A-Za-z0-9_]", effective_last)
         else ""
     )
     return f"{prefix}{pattern}{suffix}"

--- a/specs/greenhouse/extraction.xml
+++ b/specs/greenhouse/extraction.xml
@@ -92,7 +92,7 @@
         <kw canonical="Python">Python</kw>
         <kw canonical="JavaScript">JavaScript</kw>
         <kw canonical="TypeScript">TypeScript</kw>
-        <kw canonical="Go" case_sensitive="true">(?:Go|Golang)</kw>
+        <kw canonical="Go" case_sensitive="true">\b(?:Go|Golang)\b</kw>
         <kw canonical="Rust">Rust</kw>
         <kw canonical="Java">Java</kw>
         <kw canonical="Kotlin">Kotlin</kw>

--- a/tests/test_extractor_tech_gate.py
+++ b/tests/test_extractor_tech_gate.py
@@ -91,3 +91,50 @@ class TestFetchCompanyNonTechSkip:
             if not is_non_tech_title(t)
         ]
         assert results == []
+
+
+# ─── Keyword boundary regressions (Greenhouse) ──────────────────────────────
+
+
+class TestKeywordBoundaryGreenhouse:
+    """Regression tests for word-boundary false positives in Greenhouse extraction.
+
+    Bug: (?:Go|Golang) lacked \b anchors, so the Go keyword matched the substring
+    "Go" inside "Google", "Golang" inside unrelated mentions, etc.
+    Root cause: _with_word_boundary inspected pattern[0] which is '(' for a
+    non-capturing group, so no \b was prepended or appended.
+    """
+
+    def test_go_not_matched_inside_google(self, extractor: Extractor) -> None:
+        """Go must not fire when only Google is mentioned (no actual Go usage)."""
+        raw = _raw_job(
+            "Gestionnaire des Médias de Performance",
+            "Plateformes telles que Google, Meta, Amazon, TikTok.",
+        )
+        result = extractor._apply_extraction(raw, _COMPANY)
+        assert "Go" not in result["tech_stack"], (
+            "Go is a false positive: it matched 'Go' inside 'Google'. "
+            "Word-boundary enforcement must prevent this."
+        )
+
+    def test_go_detected_when_explicitly_named(self, extractor: Extractor) -> None:
+        """Go must still be extracted when the posting genuinely uses Go."""
+        raw = _raw_job(
+            "Backend Developer",
+            "We build microservices in Go and deploy with Docker.",
+        )
+        result = extractor._apply_extraction(raw, _COMPANY)
+        assert "Go" in result["tech_stack"], (
+            "Go must be detected when it appears as a standalone word."
+        )
+
+    def test_golang_detected_as_go_canonical(self, extractor: Extractor) -> None:
+        """'Golang' in the description should map to the canonical 'Go' entry."""
+        raw = _raw_job(
+            "Backend Developer",
+            "Our stack is Golang and PostgreSQL.",
+        )
+        result = extractor._apply_extraction(raw, _COMPANY)
+        assert "Go" in result["tech_stack"], (
+            "Golang must map to canonical 'Go'."
+        )


### PR DESCRIPTION
*pipeline/extractor.py : _with_word_boundary engine fix*

Two new heuristics:

- Prefix: if the pattern starts with (?:, peek at pattern[3] (first char inside the group) instead of ( to decide whether to prepend \b. Fixes (?:Go|Golang) → \b(?:Go|Golang)\b.
- Suffix: regex ([A-Za-z0-9_])\)[?*+]?…$ finds the last word char before a trailing closing paren/quantifier. Fixes patterns like REST(?:ful)? and Vue(?:\.js)? getting a proper suffix \b.

This also quietly corrects several other patterns with optional prefixes ((?:Apache )?Spark, (?:Ruby on )?Rails, etc.) that had the same latent suffix issue.

*specs/greenhouse/extraction.xml:  spec fix*

Changed (?:Go|Golang) → \b(?:Go|Golang)\b, aligning with the lever spec which already had explicit anchors. Redundant now that the engine is fixed, but explicit boundaries in the spec are the belt-and-suspenders approach and make intent clear.

*tests/test_extractor_tech_gate.py : regression tests*

Added TestKeywordBoundaryGreenhouse with three cases: Go doesn't fire on "Google", Go fires on standalone "Go", and "Golang" maps to canonical "Go".