### PR TITLE
fix: extend debug extraction to support Greenhouse and Workable ATS

### DIFF
--- a/scripts/debug_extraction.py
+++ b/scripts/debug_extraction.py
@@ -23,7 +23,6 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Any
 
 import httpx
 from lxml import etree
@@ -49,7 +48,8 @@ def _detect_ats(url: str) -> tuple[str, str, str]:
     """Return (source, slug, job_id) inferred from the job URL."""
     patterns = [
         ("lever", r"(?:jobs\.lever\.co|api\.lever\.co/v0/postings)/([^/]+)/([^/?]+)"),
-        ("greenhouse", r"(?:job-boards(?:\.eu)?\.greenhouse\.io|boards-api\.greenhouse\.io/v1/boards)/([^/]+)/jobs/([^/?]+)"),
+        ("greenhouse", r"(?:job-boards(?:\.eu)?\.greenhouse\.io"
+                       r"|boards-api\.greenhouse\.io/v1/boards)/([^/]+)/jobs/([^/?]+)"),
         ("workable", r"apply\.workable\.com/([^/]+)/j/([^/?]+)"),
     ]
     for source, pat in patterns:
@@ -85,7 +85,9 @@ def _fetch_workable(slug: str, job_id: str) -> dict:
     schema = json.loads((SPECS_DIR / "workable" / "schema.json").read_text())
     endpoint = schema["endpoint"]
     url = endpoint["url_template"].format(company_slug=slug)
-    resp = httpx.get(url, headers=_HEADERS, params=endpoint.get("params", {}), follow_redirects=True)
+    resp = httpx.get(
+        url, headers=_HEADERS, params=endpoint.get("params", {}), follow_redirects=True
+    )
     resp.raise_for_status()
     rows = Extractor._parse_markdown_table(resp.text, endpoint["columns"])
     match = next(

--- a/scripts/debug_extraction.py
+++ b/scripts/debug_extraction.py
@@ -1,34 +1,37 @@
-"""Debug extraction: show per-technology evidence for a single Lever job URL.
+"""Debug extraction: show per-technology evidence for a single job URL.
+
+Auto-detects the ATS from the URL — supports Lever, Greenhouse, and Workable.
 
 Usage:
-  python scripts/debug_extraction.py <lever_job_url>
-  python scripts/debug_extraction.py https://api.lever.co/v0/postings/bhvr/b4582013-a93f-4b94-adef-1718407eaece
+  python scripts/debug_extraction.py <job_url>
+
+Examples:
   python scripts/debug_extraction.py https://jobs.lever.co/bhvr/b4582013-a93f-4b94-adef-1718407eaece
+  python scripts/debug_extraction.py https://job-boards.eu.greenhouse.io/valtech/jobs/4850336101
+  python scripts/debug_extraction.py https://apply.workable.com/tecsys/j/ABC123
 
 For each extracted technology the report shows:
   - canonical name
   - source field (title / description_html)
   - matched text snippet (±40 chars around match)
-  - extraction method (regex)
-  - pattern used
-  - extraction spec version
-
-Output format: plain text, one block per technology.
+  - raw pattern and effective pattern (with \\b anchors)
 """
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 import httpx
 from lxml import etree
 
-# Allow running from repo root without installing the package.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from pipeline.extractor import (
+    Extractor,
     _coerce,
     _resolve_path,
     _strip_html_for_matching,
@@ -36,27 +39,86 @@ from pipeline.extractor import (
 )
 
 SPECS_DIR = Path(__file__).parent.parent / "specs"
+_HEADERS = {"User-Agent": "jobs-radar-qc/debug"}
 
 
-def _fetch_job(url: str) -> dict:
-    """Accept either a hosted URL or a direct API URL and return the raw job dict."""
-    # Convert hosted URL to API URL
-    # https://jobs.lever.co/{slug}/{id} → https://api.lever.co/v0/postings/{slug}/{id}
-    url = re.sub(
-        r"https://jobs\.lever\.co/([^/]+)/([^/?]+)",
-        r"https://api.lever.co/v0/postings/\1/\2",
-        url,
+# ─── ATS detection ───────────────────────────────────────────────────────────
+
+
+def _detect_ats(url: str) -> tuple[str, str, str]:
+    """Return (source, slug, job_id) inferred from the job URL."""
+    patterns = [
+        ("lever", r"(?:jobs\.lever\.co|api\.lever\.co/v0/postings)/([^/]+)/([^/?]+)"),
+        ("greenhouse", r"(?:job-boards(?:\.eu)?\.greenhouse\.io|boards-api\.greenhouse\.io/v1/boards)/([^/]+)/jobs/([^/?]+)"),
+        ("workable", r"apply\.workable\.com/([^/]+)/j/([^/?]+)"),
+    ]
+    for source, pat in patterns:
+        m = re.search(pat, url)
+        if m:
+            return source, m.group(1), m.group(2)
+    print(
+        "Unrecognised URL — expected a Lever, Greenhouse, or Workable job URL.\n"
+        f"Got: {url}\n\n"
+        + __doc__
     )
-    resp = httpx.get(url, headers={"User-Agent": "jobs-radar-qc/debug"}, follow_redirects=True)
+    sys.exit(1)
+
+
+# ─── Fetch strategies ────────────────────────────────────────────────────────
+
+
+def _fetch_lever(slug: str, job_id: str) -> dict:
+    url = f"https://api.lever.co/v0/postings/{slug}/{job_id}"
+    resp = httpx.get(url, headers=_HEADERS, follow_redirects=True)
     resp.raise_for_status()
     return resp.json()
 
 
-def _build_job_data(raw: dict) -> dict:
-    """Reproduce the field mapping step of _apply_extraction for Lever."""
-    spec_dir = SPECS_DIR / "lever"
-    root = etree.parse(str(spec_dir / "extraction.xml")).getroot()
+def _fetch_greenhouse(slug: str, job_id: str) -> dict:
+    url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs/{job_id}"
+    resp = httpx.get(url, headers=_HEADERS, params={"questions": "false"}, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.json()
 
+
+def _fetch_workable(slug: str, job_id: str) -> dict:
+    schema = json.loads((SPECS_DIR / "workable" / "schema.json").read_text())
+    endpoint = schema["endpoint"]
+    url = endpoint["url_template"].format(company_slug=slug)
+    resp = httpx.get(url, headers=_HEADERS, params=endpoint.get("params", {}), follow_redirects=True)
+    resp.raise_for_status()
+    rows = Extractor._parse_markdown_table(resp.text, endpoint["columns"])
+    match = next(
+        (r for r in rows if (r.get("external_id") or "").upper() == job_id.upper()),
+        None,
+    )
+    if match is None:
+        print(
+            f"Job {job_id!r} not found in {slug}'s Workable listing.\n"
+            "The job may be closed or filtered out by the Canada location param."
+        )
+        sys.exit(1)
+    return match
+
+
+def _fetch_job(source: str, slug: str, job_id: str) -> dict:
+    fetchers = {
+        "lever": _fetch_lever,
+        "greenhouse": _fetch_greenhouse,
+        "workable": _fetch_workable,
+    }
+    return fetchers[source](slug, job_id)
+
+
+# ─── Extraction helpers ──────────────────────────────────────────────────────
+
+
+def _load_spec(source: str) -> etree._Element:
+    return etree.parse(str(SPECS_DIR / source / "extraction.xml")).getroot()
+
+
+def _build_job_data(root: etree._Element, raw: dict) -> dict:
+    """Reproduce the field-mapping step of _apply_extraction for any ATS."""
     result: dict = {}
     for field in root.findall("fields/field"):
         raw_value = _resolve_path(raw, field.get("from"))
@@ -74,8 +136,7 @@ def _build_job_data(raw: dict) -> dict:
                     if isinstance(item, dict) and item.get(sub_key)
                 )
                 base = str(raw_value) if raw_value is not None else ""
-                combined = f"{base} {extra}".strip()
-                raw_value = combined or None
+                raw_value = f"{base} {extra}".strip() or None
 
         result[field.get("name")] = _coerce(raw_value, field_type, empty_as_null=empty_as_null)
     return result
@@ -91,7 +152,6 @@ def _debug_keywords(root: etree._Element, job_data: dict) -> list[dict]:
     global_flags = re.IGNORECASE if kw_el.get("case_insensitive") == "true" else 0
     word_boundary = kw_el.get("word_boundary") == "true"
 
-    # Per-source plain text for snippet extraction
     source_texts = {
         s: _strip_html_for_matching(str(job_data.get(s) or "")) for s in sources
     }
@@ -107,7 +167,6 @@ def _debug_keywords(root: etree._Element, job_data: dict) -> list[dict]:
         if not re.search(pattern, combined_text, flags):
             continue
 
-        # Find which source field and what snippet
         for src_name, src_text in source_texts.items():
             m = re.search(pattern, src_text, flags)
             if m:
@@ -129,28 +188,48 @@ def _debug_keywords(root: etree._Element, job_data: dict) -> list[dict]:
     return records
 
 
+# ─── Display helpers ─────────────────────────────────────────────────────────
+
+
+def _job_header(source: str, raw: dict, slug: str) -> tuple[str, str, str]:
+    """Return (title, company, job_id) adapted to each ATS's raw field names."""
+    if source == "lever":
+        return (
+            raw.get("text", "(no title)"),
+            raw.get("categories", {}).get("company", slug),
+            str(raw.get("id", "")),
+        )
+    if source == "greenhouse":
+        return raw.get("title", "(no title)"), slug, str(raw.get("id", ""))
+    # workable
+    return raw.get("title", "(no title)"), slug, raw.get("external_id", "")
+
+
+# ─── Entry point ─────────────────────────────────────────────────────────────
+
+
 def main() -> None:
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(1)
 
     url = sys.argv[1]
-    print(f"Fetching: {url}")
-    raw = _fetch_job(url)
+    source, slug, job_id = _detect_ats(url)
 
-    title = raw.get("text", "(no title)")
-    company = raw.get("categories", {}).get("company", "")
+    print(f"ATS:     {source}")
+    print(f"Fetching {url}")
+    raw = _fetch_job(source, slug, job_id)
+
+    title, company, raw_id = _job_header(source, raw, slug)
     print(f"\nJob:     {title}")
-    if company:
-        print(f"Company: {company}")
-    print(f"ID:      {raw.get('id')}")
+    print(f"Company: {company}")
+    print(f"ID:      {raw_id}")
 
-    spec_dir = SPECS_DIR / "lever"
-    root = etree.parse(str(spec_dir / "extraction.xml")).getroot()
+    root = _load_spec(source)
     spec_version = root.get("version", "?")
-    print(f"Spec:    specs/lever/extraction.xml  version={spec_version}")
+    print(f"Spec:    specs/{source}/extraction.xml  version={spec_version}")
 
-    job_data = _build_job_data(raw)
+    job_data = _build_job_data(root, raw)
     records = _debug_keywords(root, job_data)
 
     if not records:


### PR DESCRIPTION
# Détection automatique de l'ATS  
*_detect_ats(url) extrait (source, slug, job_id) avec trois regex couvrant les URLs hébergées et API de chaque ATS. Greenhouse accepte les deux variantes .greenhouse.io et .eu.greenhouse.io.*

Trois stratégies de fetch distinctes :

- Lever : même logique qu'avant — appel direct à l'API single-job
- Greenhouse : boards-api.greenhouse.io/v1/boards/{slug}/jobs/{id}?questions=false
- Workable : fetch du tableau markdown pour la compagnie, parse via Extractor._parse_markdown_table (réutilise le code existant), puis filtre par external_id. Affiche une erreur claire si le job est fermé ou hors du filtre Canada
_build_job_data et _debug_keywords reçoivent maintenant la root XML au lieu de hardcoder specs/lever/. Le concat_array (Lever lists[]) est toujours géré de façon générique puisque c'est déjà dans le XML spec.

*Note->* Workable : puisque description_html est null pour Workable (titre seulement), le rapport affichera uniquement des matches sur le champ title — c'est le comportement correct et attendu selon la spec.