### PR TITLE
feat: mobile bottom tab bar (Jobs · Radar · Saved · Alerts)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -97,3 +97,14 @@ body {
     max-width: 320px;
   }
 }
+
+/* ── Bottom tab bar — focus-visible ring ──────────────────────────────── */
+/*
+ * Using a CSS rule (not Tailwind utility) because the color must come from
+ * the --accent token and the selector targets a pseudo-class.
+ */
+.btb-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
+  border-radius: 4px;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import Link from "next/link";
 import "./globals.css";
+import BottomTabBar from "@/components/BottomTabBar";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -31,7 +32,12 @@ export default function RootLayout({
       lang="en"
       className={`${inter.variable} ${jetbrainsMono.variable} h-full`}
     >
-      <body className="flex min-h-full flex-col" style={{ background: "var(--bg)", color: "var(--ink)" }}>
+      {/*
+        * pb-14 (56 px) reserves room below scrollable content so nothing hides
+        * behind the fixed BottomTabBar on mobile.
+        * lg:pb-0 removes that padding on desktop where the bar is hidden.
+        */}
+      <body className="flex min-h-full flex-col pb-14 lg:pb-0" style={{ background: "var(--bg)", color: "var(--ink)" }}>
         {/* Top navigation */}
         <header
           className="sticky top-0 z-40 border-b"
@@ -103,6 +109,9 @@ export default function RootLayout({
             </a>
           </p>
         </footer>
+
+        {/* Mobile bottom navigation — hidden on lg+ where the top nav suffices */}
+        <BottomTabBar />
       </body>
     </html>
   );

--- a/frontend/components/BottomTabBar.tsx
+++ b/frontend/components/BottomTabBar.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useSyncExternalStore, type CSSProperties } from "react";
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Saved-count badge
+ * Uses the same localStorage key and custom-event bus as SavedPageClient /
+ * SaveButton so the badge stays in sync within the same tab without polling.
+ * ─────────────────────────────────────────────────────────────────────── */
+const STORAGE_KEY  = "jobs-radar-qc:saved";
+const SAVED_CHANGE = "jobs-radar-qc:saved-change";
+
+let _rawRef: string | null = null;
+let _lenCache              = 0;
+
+function getSavedCount(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === _rawRef) return _lenCache;
+    _rawRef   = raw;
+    _lenCache = raw ? (JSON.parse(raw) as unknown[]).length : 0;
+    return _lenCache;
+  } catch {
+    _rawRef   = null;
+    _lenCache = 0;
+    return 0;
+  }
+}
+
+function subscribeSaved(cb: () => void): () => void {
+  window.addEventListener(SAVED_CHANGE, cb);
+  window.addEventListener("storage",    cb);
+  return () => {
+    window.removeEventListener(SAVED_CHANGE, cb);
+    window.removeEventListener("storage",    cb);
+  };
+}
+
+/** Stable SSR snapshot — localStorage is unavailable on the server. */
+function getServerCount(): number { return 0; }
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * SVG Icons — Lucide-style, stroke 1.5, viewBox 0 0 24 24, rendered at 20 px
+ * All icons carry aria-hidden; the tab's aria-label conveys the meaning.
+ * ─────────────────────────────────────────────────────────────────────── */
+function BriefcaseIcon() {
+  return (
+    <svg
+      width="20" height="20" viewBox="0 0 24 24"
+      fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+      <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+    </svg>
+  );
+}
+
+function ActivityIcon() {
+  return (
+    <svg
+      width="20" height="20" viewBox="0 0 24 24"
+      fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden
+    >
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </svg>
+  );
+}
+
+function StarIcon() {
+  return (
+    <svg
+      width="20" height="20" viewBox="0 0 24 24"
+      fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden
+    >
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+    </svg>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg
+      width="20" height="20" viewBox="0 0 24 24"
+      fill="none" stroke="currentColor"
+      strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Badge pill — shown above the icon when count > 0.
+ * aria-hidden: count is already woven into the tab's aria-label.
+ * ─────────────────────────────────────────────────────────────────────── */
+function CountBadge({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return (
+    <span
+      aria-hidden
+      style={{
+        position: "absolute",
+        top: 6,
+        /* Push the badge right of center so it doesn't overlap the icon */
+        left: "calc(50% + 4px)",
+        background: "var(--accent)",
+        color: "var(--surface)",
+        fontFamily: "var(--font-mono)",
+        fontSize: 9,
+        fontWeight: 600,
+        minWidth: 14,
+        height: 14,
+        borderRadius: 999,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "0 3px",
+        lineHeight: 1,
+      }}
+    >
+      {count > 99 ? "99+" : count}
+    </span>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Active underline — 2 px accent strip at the bottom of the active tab.
+ * ─────────────────────────────────────────────────────────────────────── */
+function ActiveUnderline() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        position: "absolute",
+        bottom: 0,
+        left: "50%",
+        transform: "translateX(-50%)",
+        width: 24,
+        height: 2,
+        background: "var(--accent)",
+        borderRadius: 1,
+      }}
+    />
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Shared tab styles
+ * ─────────────────────────────────────────────────────────────────────── */
+const tabBase: CSSProperties = {
+  position: "relative",
+  display: "flex",
+  flex: 1,
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 3,
+  height: 54,       /* visual height of the tab strip */
+  minHeight: 44,    /* a11y: minimum touch target */
+  fontSize: 10,
+  fontFamily: "var(--font-sans)",
+  textDecoration: "none",
+  transition: "color 120ms ease-out",
+  cursor: "pointer",
+  background: "none",
+  border: "none",
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * BottomTabBar
+ * Rendered only on mobile via `lg:hidden`. The layout adds `pb-14 lg:pb-0`
+ * to <body> so page content never scrolls behind the bar.
+ * ─────────────────────────────────────────────────────────────────────── */
+export default function BottomTabBar() {
+  const pathname   = usePathname();
+  const savedCount = useSyncExternalStore(subscribeSaved, getSavedCount, getServerCount);
+
+  const active =
+    pathname === "/"       ? "jobs"  :
+    pathname === "/trends" ? "radar" :
+    pathname === "/saved"  ? "saved" :
+    "none";
+
+  function tabColor(key: string) {
+    return active === key ? "var(--accent)" : "var(--ink-mute)";
+  }
+
+  function tabWeight(key: string): number {
+    return active === key ? 600 : 400;
+  }
+
+  return (
+    <nav
+      /*
+       * `flex` sets display:flex via a CSS class; `lg:hidden` sets display:none
+       * at ≥1024px via a responsive class. Both are CSS-class rules — Tailwind's
+       * responsive variant wins at the lg breakpoint because it is later in the
+       * generated stylesheet. An inline style would permanently override lg:hidden,
+       * so we intentionally keep display OUT of the style prop.
+       */
+      className="flex lg:hidden"
+      role="tablist"
+      aria-label="Navigation principale"
+      style={{
+        position: "fixed",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 50,
+        background: "var(--surface)",
+        borderTop: "1px solid var(--rule-soft)",
+        /* Extend into the iOS home-indicator safe area */
+        paddingBottom: "env(safe-area-inset-bottom)",
+      }}
+    >
+      {/* ── Jobs ───────────────────────────────────────────────────────── */}
+      <Link
+        href="/"
+        role="tab"
+        aria-selected={active === "jobs"}
+        aria-label="Jobs"
+        className="btb-tab"
+        style={{ ...tabBase, color: tabColor("jobs"), fontWeight: tabWeight("jobs") }}
+      >
+        <BriefcaseIcon />
+        <span>Jobs</span>
+        {active === "jobs" && <ActiveUnderline />}
+      </Link>
+
+      {/* ── Radar ──────────────────────────────────────────────────────── */}
+      <Link
+        href="/trends"
+        role="tab"
+        aria-selected={active === "radar"}
+        aria-label="Radar"
+        className="btb-tab"
+        style={{ ...tabBase, color: tabColor("radar"), fontWeight: tabWeight("radar") }}
+      >
+        <ActivityIcon />
+        <span>Radar</span>
+        {active === "radar" && <ActiveUnderline />}
+      </Link>
+
+      {/* ── Saved ──────────────────────────────────────────────────────── */}
+      <Link
+        href="/saved"
+        role="tab"
+        aria-selected={active === "saved"}
+        aria-label={savedCount > 0 ? `Saved, ${savedCount} enregistré${savedCount !== 1 ? "s" : ""}` : "Saved"}
+        className="btb-tab"
+        style={{ ...tabBase, color: tabColor("saved"), fontWeight: tabWeight("saved") }}
+      >
+        <StarIcon />
+        <span>Saved</span>
+        <CountBadge count={savedCount} />
+        {active === "saved" && <ActiveUnderline />}
+      </Link>
+
+      {/* ── Alerts (no route yet — button placeholder) ─────────────────── */}
+      <button
+        type="button"
+        role="tab"
+        aria-selected={false}
+        aria-label="Alerts"
+        className="btb-tab"
+        style={{ ...tabBase, color: "var(--ink-mute)", fontWeight: 400 }}
+      >
+        <BellIcon />
+        <span>Alerts</span>
+      </button>
+    </nav>
+  );
+}


### PR DESCRIPTION
Closes #27

## What changed

- **New component** `frontend/components/BottomTabBar.tsx` — client component, fixed to the bottom of the viewport on mobile only
- **`layout.tsx`** — imports `BottomTabBar`, adds `pb-14 lg:pb-0` to `<body>` so content scrolls above the bar
- **`globals.css`** — adds `.btb-tab:focus-visible` ring rule using `--accent`

## Behaviour

| Property | Value |
|---|---|
| Visible | `< lg` (< 1024 px) |
| Hidden | `lg:hidden` → `display: none` |
| Height | 54 px visual + `env(safe-area-inset-bottom)` |
| Hit target | min-height 44 px per tab |
| Active state | `font-weight: 600` + 2 px `--accent` underline |
| Saved badge | `useSyncExternalStore` on `jobs-radar-qc:saved` (same event bus as `SaveButton` / `SavedPageClient`) |
| ARIA | `role="tablist"`, `role="tab"`, `aria-selected`, `aria-label` per tab |
| Focus | `.btb-tab:focus-visible` outline in `--accent` |
| Motion | `color 120ms ease-out` — suppressed by `prefers-reduced-motion` global rule |

## Key implementation note

`display` is set via `className="flex lg:hidden"`, not in the inline `style` prop. Inline styles permanently beat CSS class rules, which would silently break `lg:hidden` on desktop.

## Open questions / risks

- **Alerts tab** has no route yet — it is a non-navigating `<button>` placeholder. A `/alerts` route (or modal) needs to be added in a follow-up issue to make this tab functional.
- Safe-area padding: `pb-14` (56 px) covers the bar on most devices; iPhones with a large home indicator (~34 px) add `env(safe-area-inset-bottom)` to the bar itself, so content padding may be slightly short on those. A follow-up can replace `pb-14` with a CSS custom property that accounts for the safe area.

## Verification

- `npm run lint` → 0 errors
- `npx tsc --noEmit` → exit 0
- `npm run build` → compiled successfully
- Playwright at 375, 768, 1024, 1440 px:
  - Bar `display: flex` at 375 and 768
  - Bar `display: none` at 1024 and 1440
  - Active tab `font-weight: 600` + underline span confirmed
  - 0 console errors across all routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)