### PR TITLE
Update canonical tech stack to 76 technologies across 10 categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Jobs Radar QC is an open-source, spec-driven job market radar that tracks Quebec tech roles directly from ATS platforms, extracts the technologies companies are hiring for, and visualizes stack demand over time.
 
-| 37 companies tracked | 73 canonical technologies | ~2M tokens/week | ~41% prompt cache hit rate |
+| 37 companies tracked | 76 canonical technologies | ~2M tokens/week | ~41% prompt cache hit rate |
 |---|---|---|---|
 | across 3 ATS platforms | in extraction stack | LLM enrichment volume | ~$2/week saved vs baseline |
 
@@ -33,7 +33,7 @@ Jobs Radar QC is an open-source, spec-driven job market radar that tracks Quebec
 - 37 Quebec tech companies tracked
 - Daily automated fetch via GitHub Actions
 - Weekly LLM enrichment (Claude Haiku, Sundays)
-- 73 canonical technologies tracked
+- 76 canonical technologies tracked across 10 categories (v2)
 - Active job trends at `/trends`
 - ~41% prompt cache hit rate — ~$2/week saved vs uncached baseline (observed in production)
 
@@ -226,7 +226,7 @@ agents/
 
 core/
   canonical_schema.json     # Unified Job model (JSON Schema draft-07)
-  canonical_tech_stack.json # 73 canonical tech names by category
+  canonical_tech_stack.json # 76 canonical tech names across 10 categories (v2)
 
 specs/
   greenhouse/               # 14 QC companies (Broadsign, AppDirect, AlayaCare, Valtech, Workleap, ShareGate, Epic Games, Speechify, AON3D, LATYS, GURUS Solutions, Samsara, Ivalua, Toboggan Labs)

--- a/core/canonical_tech_stack.json
+++ b/core/canonical_tech_stack.json
@@ -1,36 +1,41 @@
 {
-  "version": "1",
+  "version": "2",
   "categories": {
     "languages": [
-      "Python", "JavaScript", "TypeScript", "Go", "Rust",
-      "Java", "Kotlin", "Scala", "C#", "C++",
-      "Ruby", "PHP", "Swift", "Elixir", "Erlang", "R"
+      "Python", "Java", "TypeScript", "JavaScript", "C#", "Go",
+      "SQL", "Kotlin", "Swift", "Rust"
     ],
     "frontend": [
-      "React", "Next.js", "Vue", "Angular", "Svelte",
-      "Node.js", "Express", "GraphQL", "REST"
+      "React", "Next.js", "Angular", "Vue", "Tailwind", "Redux", "Svelte"
     ],
     "backend": [
-      "Django", "FastAPI", "Flask", "Rails", "Spring",
-      "Laravel", "ASP.NET", ".NET", "gRPC", "Celery"
+      "Spring Boot", "Node.js", "Express", "NestJS", ".NET",
+      "Django", "FastAPI", "GraphQL", "REST", "gRPC"
     ],
     "databases": [
-      "PostgreSQL", "MySQL", "MongoDB", "Redis", "Elasticsearch",
-      "Snowflake", "BigQuery", "DynamoDB", "Cassandra", "ClickHouse"
+      "PostgreSQL", "MySQL", "MongoDB", "Redis",
+      "DynamoDB", "Snowflake", "Elasticsearch", "ClickHouse"
     ],
-    "infrastructure": [
-      "AWS", "GCP", "Azure", "Kubernetes", "Docker",
-      "Terraform", "Ansible", "CI/CD", "GitHub Actions"
+    "cloud": [
+      "AWS", "Azure", "GCP", "Linux", "Nginx", "Cloudflare"
     ],
-    "data": [
-      "Spark", "Kafka", "Airflow", "dbt", "Flink",
-      "Temporal", "Databricks", "RabbitMQ",
-      "Pandas", "NumPy", "PyTorch", "TensorFlow", "scikit-learn"
+    "devops": [
+      "Docker", "Kubernetes", "Terraform", "Helm",
+      "GitHub Actions", "Jenkins", "ArgoCD",
+      "Prometheus", "Grafana", "Ansible"
+    ],
+    "data_ai": [
+      "Pandas", "Spark", "Databricks", "Airflow",
+      "TensorFlow", "PyTorch", "LangChain", "OpenAI",
+      "Vector DB", "dbt", "Kafka", "MLflow"
     ],
     "mobile": [
-      "React Native", "Flutter", "Android", "iOS"
+      "React Native", "Flutter", "SwiftUI", "Android", "iOS"
     ],
-    "other": [
+    "testing": [
+      "Jest", "Cypress", "Playwright", "Selenium", "JUnit", "Postman"
+    ],
+    "ai_concepts": [
       "LLM", "RAG"
     ]
   }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ The `active_qc_jobs` Supabase view merges both columns (`tech_stack || enriched_
 | `pipeline/extractor.py` | Generic spec-driven fetch and extraction engine |
 | `pipeline/orchestrator.py` | Runs all specs in parallel, writes to DB |
 | `specs/{ats}/extraction.xml` | Declarative field mappings and derivation rules |
-| `core/canonical_tech_stack.json` | 73 canonical tech names used by both layers |
+| `core/canonical_tech_stack.json` | 76 canonical tech names across 10 categories (v2) used by both layers |
 | `agents/enricher.py` | LLM enrichment pass |
 | `agents/prompts/tech_extraction.md` | Versioned system prompt — editable without code changes |
 | `storage/jobs_repository.py` | `upsert_jobs()`, `mark_inactive()` |

--- a/docs/linkedin-post.md
+++ b/docs/linkedin-post.md
@@ -56,7 +56,7 @@ Greenhouse, Lever, and Workable are what companies actually manage. If a job is 
 
 **Slide 3 — The architecture**
 Spec-driven Python pipeline → Canonical job schema → Supabase/PostgreSQL → Weekly Claude Haiku enrichment → active_qc_jobs view → Next.js Tech Stack Radar.
-3 ATS platforms. 12 companies. 73 canonical technologies. Daily fetch. Weekly LLM pass.
+3 ATS platforms. 12 companies. 76 canonical technologies. Daily fetch. Weekly LLM pass.
 
 **Slide 4 — The engineering lesson**
 Deterministic-first. LLM second. Evidence-based extraction.

--- a/docs/tech-stack-radar.md
+++ b/docs/tech-stack-radar.md
@@ -28,18 +28,20 @@ The Supabase `active_qc_jobs` view merges both columns (`tech_stack || enriched_
 
 ## Canonical technology list
 
-73 technologies tracked across 8 categories. Adding a technology to this list invalidates all stored prompt hashes and triggers a full re-enrichment on the next Sunday run.
+76 technologies tracked across 10 categories (v2). Adding a technology to this list invalidates all stored prompt hashes and triggers a full re-enrichment on the next Sunday run.
 
 | Category | Technologies |
 |---|---|
-| Languages | Python, JavaScript, TypeScript, Go, Rust, Java, Kotlin, Scala, C#, C++, Ruby, PHP, Swift, Elixir, Erlang, R |
-| Frontend | React, Next.js, Vue, Angular, Svelte, Node.js, Express, GraphQL, REST |
-| Backend | Django, FastAPI, Flask, Rails, Spring, Laravel, ASP.NET, .NET, gRPC, Celery |
-| Databases | PostgreSQL, MySQL, MongoDB, Redis, Elasticsearch, Snowflake, BigQuery, DynamoDB, Cassandra, ClickHouse |
-| Infrastructure | AWS, GCP, Azure, Kubernetes, Docker, Terraform, Ansible, CI/CD, GitHub Actions |
-| Data & ML | Spark, Kafka, Airflow, dbt, Flink, Temporal, Databricks, RabbitMQ, Pandas, NumPy, PyTorch, TensorFlow, scikit-learn |
-| Mobile | React Native, Flutter, Android, iOS |
-| Other | LLM, RAG |
+| Languages | Python, Java, TypeScript, JavaScript, C#, Go, SQL, Kotlin, Swift, Rust |
+| Frontend | React, Next.js, Angular, Vue, Tailwind, Redux, Svelte |
+| Backend | Spring Boot, Node.js, Express, NestJS, .NET, Django, FastAPI, GraphQL, REST, gRPC |
+| Databases | PostgreSQL, MySQL, MongoDB, Redis, DynamoDB, Snowflake, Elasticsearch, ClickHouse |
+| Cloud | AWS, Azure, GCP, Linux, Nginx, Cloudflare |
+| DevOps | Docker, Kubernetes, Terraform, Helm, GitHub Actions, Jenkins, ArgoCD, Prometheus, Grafana, Ansible |
+| Data & AI | Pandas, Spark, Databricks, Airflow, TensorFlow, PyTorch, LangChain, OpenAI, Vector DB, dbt, Kafka, MLflow |
+| Mobile | React Native, Flutter, SwiftUI, Android, iOS |
+| Testing | Jest, Cypress, Playwright, Selenium, JUnit, Postman |
+| AI Concepts | LLM, RAG |
 
 The canonical list lives in [`core/canonical_tech_stack.json`](../core/canonical_tech_stack.json).
 

--- a/tests/test_prompt_hash.py
+++ b/tests/test_prompt_hash.py
@@ -55,7 +55,7 @@ class TestRenderSystemPrompt:
         rendered = render_system_prompt()
         assert "Python" in rendered
         assert "Kubernetes" in rendered
-        assert "Temporal" in rendered
+        assert "LangChain" in rendered  # new in v2; Temporal was removed
 
     def test_categories_present(self):
         rendered = render_system_prompt()


### PR DESCRIPTION
## Restructure canonical_tech_stack.json

Implements the technical restructuring proposed in #58.

**Changes:**
- Consolidates 8 categories → 10 categories (separates Cloud/DevOps, adds Testing/QA)
- Aligns categories with Quebec ATS job description conventions
- Adds missing market-standard technologies (Tailwind, NestJS, ArgoCD, LangChain, etc.)
- Bumps schema version

**Files:**
- `canonical_tech_stack.json`

**Note:** This invalidates all cached enrichments and triggers full re-processing on the next weekly run (intentional).

Closes #58