### PR TITLE
fix: Workable Layer 1 — fetch job description via .md detail URL (#56)

### DIFF
--- a/pipeline/extractor.py
+++ b/pipeline/extractor.py
@@ -20,6 +20,10 @@ logger = structlog.get_logger()
 
 SPECS_DIR = Path(__file__).parent.parent / "specs"
 
+# Maximum number of concurrent Workable detail-page requests.
+# Keeps the per-company fetch polite while still being meaningfully parallel.
+_WORKABLE_DETAIL_CONCURRENCY = 5
+
 
 # ─── Spec loading ────────────────────────────────────────────────────────────
 
@@ -138,9 +142,7 @@ def _with_word_boundary(pattern: str) -> str:
         return pattern
     # For patterns that start with a non-capturing group (?:...), peek at the
     # first character inside the group rather than the literal '(' character.
-    effective_first = (
-        pattern[3] if pattern.startswith(r"(?:") and len(pattern) > 3 else pattern[0]
-    )
+    effective_first = pattern[3] if pattern.startswith(r"(?:") and len(pattern) > 3 else pattern[0]
     prefix = (
         r"\b"
         if not pattern.startswith(r"\b") and re.match(r"[A-Za-z0-9_]", effective_first)
@@ -151,9 +153,7 @@ def _with_word_boundary(pattern: str) -> str:
     trailing = re.search(r"([A-Za-z0-9_])\)[?*+]?(?:\{[^}]*\})?$", pattern)
     effective_last = trailing.group(1) if trailing else pattern[-1]
     suffix = (
-        r"\b"
-        if not pattern.endswith(r"\b") and re.match(r"[A-Za-z0-9_]", effective_last)
-        else ""
+        r"\b" if not pattern.endswith(r"\b") and re.match(r"[A-Za-z0-9_]", effective_last) else ""
     )
     return f"{prefix}{pattern}{suffix}"
 
@@ -229,6 +229,10 @@ class Extractor:
             data = response.json()
             raw_jobs = data if jobs_path is None else data.get(jobs_path, [])
 
+        # Source-specific pre-extraction enrichment (e.g. Workable detail-page fetch).
+        # Must not make LLM calls — Layer 1 invariant.
+        await self._enrich_raw_jobs(client, raw_jobs)
+
         required = self.schema.get("validation", {}).get("required_fields", [])
 
         results = []
@@ -244,6 +248,66 @@ class Extractor:
 
         log.info("fetched", count=len(results))
         return results
+
+    async def _enrich_raw_jobs(self, client: httpx.AsyncClient, raw_jobs: list[dict]) -> None:
+        """Source-specific hook to enrich raw jobs before extraction.
+
+        Called after the list response is parsed but before ``_apply_extraction``
+        runs on each job. Must never make LLM calls (Layer 1 invariant).
+        """
+        if self.source == "workable":
+            await self._fetch_workable_descriptions(client, raw_jobs)
+
+    async def _fetch_workable_descriptions(
+        self, client: httpx.AsyncClient, raw_jobs: list[dict]
+    ) -> None:
+        """Fetch each Workable job's ``.md`` detail page and inject ``description_html``.
+
+        The list endpoint (``jobs.md``) does not include job descriptions; each row
+        carries a ``_detail_url`` pointing to the full Markdown detail page
+        (``https://apply.workable.com/{slug}/jobs/view/{SHORTCODE}.md``).
+
+        Requests are bounded to ``_WORKABLE_DETAIL_CONCURRENCY`` concurrent fetches.
+        A failed detail fetch is logged and the job continues with ``description_html``
+        absent (the extraction XML falls back to the ``null`` constant so the job is
+        still written to the DB — tech_stack will be title-only for that record).
+        """
+        sem = asyncio.Semaphore(_WORKABLE_DETAIL_CONCURRENCY)
+        seen: set[str] = set()  # guard against duplicate shortcodes in the same run
+
+        async def _fetch_one(raw_job: dict) -> None:
+            detail_url: str | None = raw_job.get("_detail_url")
+            # Guard against absent, relative, or already-seen URLs.
+            if not detail_url or not detail_url.startswith("https://") or detail_url in seen:
+                if detail_url and not detail_url.startswith("https://"):
+                    logger.warning("workable_detail_url_not_absolute", url=detail_url)
+                return
+            seen.add(detail_url)
+
+            async with sem:
+                try:
+                    resp = await client.get(detail_url, timeout=30.0)
+                    resp.raise_for_status()
+                    raw_job["description_html"] = resp.text
+                    logger.debug(
+                        "workable_detail_fetched",
+                        url=detail_url,
+                        bytes=len(resp.content),
+                    )
+                except httpx.HTTPStatusError as exc:
+                    logger.warning(
+                        "workable_detail_http_error",
+                        url=detail_url,
+                        status=exc.response.status_code,
+                    )
+                except httpx.HTTPError as exc:
+                    logger.warning(
+                        "workable_detail_fetch_failed",
+                        url=detail_url,
+                        error=str(exc),
+                    )
+
+        await asyncio.gather(*(_fetch_one(job) for job in raw_jobs))
 
     @staticmethod
     def _parse_markdown_table(text: str, columns: list[str]) -> list[dict]:

--- a/specs/workable/extraction.xml
+++ b/specs/workable/extraction.xml
@@ -6,17 +6,27 @@
   The extractor parses the table using schema.json "columns" as field names
   and auto-derives external_id and source_url from the _detail_url cell.
 
-  Key limitations vs JSON sources:
-  - No description_html: description is not included in the list endpoint
-  - tech_stack derived from title only (sources="title")
+  Detail-page fetch (Layer 1, deterministic):
+    After fetching the list, the extractor concurrently GETs each job's
+    _detail_url (https://apply.workable.com/{slug}/jobs/view/{SHORTCODE}.md)
+    and injects the full Markdown content into description_html before
+    XML extraction runs.  If the fetch fails the field stays null (fallback
+    constant below) and tech_stack falls back to title-only for that record.
+
+  Key differences vs JSON sources:
+  - description_html comes from the .md detail page, not the list endpoint
+  - tech_stack uses both title and description_html
   - posted_at is a date only (midnight UTC)
   - employment_type is often missing (— → null)
 -->
-<extraction source="workable" version="1">
+<extraction source="workable" version="2">
 
   <constants>
     <constant name="source"             value="workable" />
     <constant name="is_active"          value="true"     type="bool" />
+    <!-- Fallback: overridden by the description_html field below when the
+         detail-page fetch succeeds. Stays null on fetch failures so the job
+         is still upserted with title-only tech_stack. -->
     <constant name="description_html"   value="null"     />
   </constants>
 
@@ -24,6 +34,10 @@
     <!-- Auto-derived by the markdown parser from the _detail_url cell -->
     <field name="external_id" from="external_id"   type="string" />
     <field name="source_url"  from="source_url"    type="string" />
+
+    <!-- description_html is injected by the extractor from the .md detail page
+         before extraction runs; overrides the null constant above. -->
+    <field name="description_html" from="description_html" type="string" nullable="true" />
 
     <!-- Direct column mappings -->
     <field name="title"            from="title"            type="string" />
@@ -69,9 +83,10 @@
       <match source="title" pattern="(?i)\b(manager|gestionnaire|responsable)\b"           value="manager"    />
     </field>
 
-    <!-- tech_stack from title only — no description available for Workable -->
+    <!-- tech_stack from title + description_html (injected from the .md detail page).
+         Falls back to title only when description_html is null (failed detail fetch). -->
     <field name="tech_stack" type="list[string]" default="[]" strategy="collect-all">
-      <keywords sources="title" word_boundary="true" case_insensitive="true">
+      <keywords sources="title,description_html" word_boundary="true" case_insensitive="true">
         <kw canonical="Python">Python</kw>
         <kw canonical="JavaScript">JavaScript</kw>
         <kw canonical="TypeScript">TypeScript</kw>

--- a/specs/workable/source.md
+++ b/specs/workable/source.md
@@ -102,10 +102,38 @@ curl -s "https://apply.workable.com/{slug}/jobs.md?location%5B0%5D%5Bcountry%5D=
 
 ---
 
+## Detail-page fetch strategy
+
+The list endpoint does not include job descriptions; `description_html` must be
+fetched separately for each job.
+
+**Detail URL** (already parsed from the `_detail_url` table column):
+```
+GET https://apply.workable.com/{slug}/jobs/view/{SHORTCODE}.md
+```
+This returns the full Markdown document with Description + Requirements sections.
+
+**Concurrency:** The extractor fetches all detail pages for a company in parallel,
+bounded to `_WORKABLE_DETAIL_CONCURRENCY = 5` simultaneous requests via a semaphore.
+
+**Fallback behaviour:** If a detail fetch fails (network error, 4xx/5xx), the job is
+still processed with `description_html = null`. `tech_stack` falls back to title-only
+for that record; the job is not dropped.
+
+**Why the `.md` URL and not `/j/{SHORTCODE}`?**
+The human-facing `/j/{SHORTCODE}` page is a JavaScript Single Page Application; it
+returns only a loading spinner in raw HTML. The `.md` endpoint is the same
+machine-readable URL used by the list endpoint and returns static Markdown — no
+JavaScript rendering required.
+
+---
+
 ## Known quirks
 
-1. **No description available from the list endpoint** — `description_html` will always
-   be `null` for Workable jobs. `tech_stack` is derived from `title` only.
+1. **Description from detail fetch, not the list endpoint** — the list endpoint does
+   not include descriptions; `description_html` is populated via a secondary fetch
+   of each job's `.md` detail URL. `tech_stack` uses both `title` and
+   `description_html`.
 2. **`Type` column is often `—`** — many postings omit employment type; `employment_type`
    will frequently be `null`.
 3. **Location includes workplace type** — strip `(Hybrid)`, `(Remote)`, `(On-site)` if

--- a/tests/fixtures/workable_tecsys_sre_raw.json
+++ b/tests/fixtures/workable_tecsys_sre_raw.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Simulated raw row as produced by _parse_markdown_table + _fetch_workable_descriptions for a Tecsys SRE posting. Technologies (AWS, Kubernetes, Python, Docker, Jenkins, .NET) appear only in description_html, NOT in the title — this is the core regression scenario for issue #56.",
+  "title": "Site Reliability Engineer",
+  "department": "PT - CLOUD Infrastructure",
+  "location": "Montreal, Canada (Hybrid)",
+  "_employment_raw": "Full-time",
+  "_salary": null,
+  "_posted_raw": "2026-05-04",
+  "_detail_url": "https://apply.workable.com/tecsys/jobs/view/42A53FB11F.md",
+  "external_id": "42A53FB11F",
+  "source_url": "https://apply.workable.com/tecsys/j/42A53FB11F",
+  "description_html": "# Site Reliability Engineer\n\n> Tecsys Inc. · Montreal, Canada (Hybrid) · Full-time · Posted 2026-05-04\n\n**Workplace:** hybrid\n\n**Department:** PT - CLOUD Infrastructure\n\n## Description\n\nWe are looking for a Site Reliability Engineer to join our NOC, a team at the heart of platform reliability for mission-critical SaaS environments. You will help maintain, optimize, and ensure the reliability and performance of the systems that power our cloud infrastructure across AWS and Kubernetes, with a strong focus on automation, observability, and continuous improvement.\n\n## Requirements\n\n### Tools used\n\n- AWS (multi-account, VPC, EC2, EKS)\n- Kubernetes\n- Datadog\n- Terraform\n- GitLab CI/CD (Jenkins acceptable)\n\n### Qualifications\n\n- 5+ years in Site Reliability, Cloud, or DevOps Engineering.\n- Proven experience managing cloud infrastructure in AWS and Kubernetes at scale.\n- Strong hands-on experience with IaC and automation (Terraform, Ansible, or similar).\n- Scripting skills in Python, Bash, Java or equivalent for automation and diagnostics.\n- Familiarity with CI/CD pipelines and release automation (Jenkins).\n- Using Docker for containerization.\n- Basic knowledge of Java- or .Net-based development required."
+}

--- a/tests/test_workable_detail_fetch.py
+++ b/tests/test_workable_detail_fetch.py
@@ -1,0 +1,266 @@
+"""Regression tests for Workable Layer-1 detail-page description fetch (issue #56).
+
+Before the fix, the Workable extractor never populated ``description_html`` — the
+constant was always ``null`` and ``tech_stack`` was derived from the job title only.
+
+After the fix:
+  1. ``_fetch_workable_descriptions`` fetches each job's ``.md`` detail page and
+     injects the Markdown content as ``description_html`` into the raw row dict.
+  2. ``extraction.xml`` maps that field and uses ``sources="title,description_html"``
+     for ``tech_stack`` keyword matching.
+
+These tests exercise ``_apply_extraction`` in isolation (no network calls) with a
+fixture that simulates a row produced by the markdown-table parser AFTER the
+description has already been injected.  A separate async test validates that the
+enrichment path correctly populates ``description_html`` from a mocked HTTP client.
+
+Fixture: ``tests/fixtures/workable_tecsys_sre_raw.json``
+  A Tecsys "Site Reliability Engineer" posting whose technologies (AWS, Kubernetes,
+  Python, Docker, Jenkins) appear only in the description — not in the title.
+  Before the fix, tech_stack would be ``[]`` for this job.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pipeline.extractor import Extractor
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+_COMPANY_TECSYS = {"name": "Tecsys", "slug": "tecsys"}
+
+
+@pytest.fixture(scope="module")
+def workable() -> Extractor:
+    return Extractor("workable")
+
+
+@pytest.fixture(scope="module")
+def sre_raw() -> dict:
+    return json.loads((FIXTURES / "workable_tecsys_sre_raw.json").read_text())
+
+
+# ─── Core regression: techs in description are now extracted ─────────────────
+
+
+class TestWorkableDescriptionExtraction:
+    """Issue #56: tech_stack must be populated from description_html, not title only."""
+
+    def test_techs_in_description_are_extracted(self, workable: Extractor, sre_raw: dict) -> None:
+        """Technologies mentioned only in the description must appear in tech_stack."""
+        result = workable._apply_extraction(sre_raw, _COMPANY_TECSYS)
+        stack = set(result["tech_stack"])
+        # These techs appear in the description but NOT in the title
+        expected = {"AWS", "Kubernetes", "Python", "Docker", "Jenkins"}
+        missing = expected - stack
+        assert not missing, (
+            f"Technologies from description_html are missing from tech_stack: {missing}. "
+            "The detail-page fetch must inject description_html before extraction runs."
+        )
+
+    def test_title_still_contributes(self, workable: Extractor, sre_raw: dict) -> None:
+        """Techs in the title continue to be extracted alongside description techs."""
+        # The fixture title 'Site Reliability Engineer' has no tech keywords,
+        # so this test verifies that the two sources are correctly unioned.
+        result = workable._apply_extraction(sre_raw, _COMPANY_TECSYS)
+        assert isinstance(result["tech_stack"], list)
+        assert len(result["tech_stack"]) > 0
+
+    def test_description_html_populated(self, workable: Extractor, sre_raw: dict) -> None:
+        """description_html must be the injected Markdown content, not null."""
+        result = workable._apply_extraction(sre_raw, _COMPANY_TECSYS)
+        assert result["description_html"] is not None
+        assert "AWS" in result["description_html"]
+
+    def test_no_enriched_tech_stack(self, workable: Extractor, sre_raw: dict) -> None:
+        """Layer 1 must never write enriched_tech_stack."""
+        result = workable._apply_extraction(sre_raw, _COMPANY_TECSYS)
+        assert "enriched_tech_stack" not in result
+
+
+# ─── Fallback: failed detail fetch preserves the job ────────────────────────
+
+
+class TestWorkableDetailFetchFallback:
+    """A job with no description_html (failed fetch) must still be extracted."""
+
+    def test_title_only_fallback(self, workable: Extractor) -> None:
+        """When description_html is missing, extraction succeeds with title-only stack."""
+        raw_no_desc = {
+            "title": "Senior React Developer",
+            "department": "Engineering",
+            "location": "Montreal, Canada (Hybrid)",
+            "_employment_raw": "Full-time",
+            "_posted_raw": "2026-05-01",
+            "_detail_url": "https://apply.workable.com/testco/jobs/view/AABBCCDD11.md",
+            "external_id": "AABBCCDD11",
+            "source_url": "https://apply.workable.com/testco/j/AABBCCDD11",
+            # description_html intentionally absent — simulates a failed fetch
+        }
+        result = workable._apply_extraction(raw_no_desc, {"name": "TestCo", "slug": "testco"})
+        assert result["description_html"] is None, "Fallback constant must be null"
+        assert "React" in result["tech_stack"], "React from title must still be extracted"
+
+    def test_null_description_html_no_crash(self, workable: Extractor) -> None:
+        """Explicit null description_html must not crash keyword collection."""
+        raw = {
+            "title": "Backend Developer",
+            "department": "R&D",
+            "location": "Montreal, Canada",
+            "_employment_raw": None,
+            "_posted_raw": "2026-05-01",
+            "_detail_url": None,
+            "external_id": "NULLTEST01",
+            "source_url": "https://apply.workable.com/testco/j/NULLTEST01",
+            "description_html": None,
+        }
+        result = workable._apply_extraction(raw, {"name": "TestCo", "slug": "testco"})
+        assert isinstance(result["tech_stack"], list)
+
+
+# ─── Async: _fetch_workable_descriptions injects description_html ────────────
+
+
+class TestFetchWorkableDescriptions:
+    """Unit test for the async detail-fetch method (no real HTTP calls)."""
+
+    @pytest.mark.asyncio
+    async def test_description_injected(self, workable: Extractor) -> None:
+        """A successful detail fetch injects description_html into the raw job dict."""
+        raw_job: dict = {
+            "_detail_url": "https://apply.workable.com/testco/jobs/view/AABBCCDD11.md",
+        }
+        mock_resp = MagicMock()
+        mock_resp.text = "# Engineer\n\n## Description\n\nWe use Python and Docker."
+        mock_resp.content = mock_resp.text.encode()
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        await workable._fetch_workable_descriptions(mock_client, [raw_job])
+
+        assert raw_job["description_html"] == mock_resp.text
+        mock_client.get.assert_awaited_once_with(
+            "https://apply.workable.com/testco/jobs/view/AABBCCDD11.md",
+            timeout=30.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_http_error_does_not_raise(self, workable: Extractor) -> None:
+        """An HTTP error on a detail fetch must be swallowed — job must survive."""
+        import httpx
+
+        raw_job: dict = {
+            "_detail_url": "https://apply.workable.com/testco/jobs/view/DEADBEEF11.md",
+        }
+        mock_request = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=httpx.HTTPStatusError("404", request=mock_request, response=mock_response)
+        )
+
+        # Must not raise
+        await workable._fetch_workable_descriptions(mock_client, [raw_job])
+
+        assert "description_html" not in raw_job, (
+            "description_html must not be set when the fetch fails"
+        )
+
+    @pytest.mark.asyncio
+    async def test_network_error_does_not_raise(self, workable: Extractor) -> None:
+        """A network-level error on a detail fetch must be swallowed."""
+        import httpx
+
+        raw_job: dict = {
+            "_detail_url": "https://apply.workable.com/testco/jobs/view/NETFAIL001.md",
+        }
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("timeout"))
+
+        await workable._fetch_workable_descriptions(mock_client, [raw_job])
+
+        assert "description_html" not in raw_job
+
+    @pytest.mark.asyncio
+    async def test_duplicate_detail_url_fetched_once(self, workable: Extractor) -> None:
+        """Two jobs with identical _detail_url must trigger only one HTTP request."""
+        shared_url = "https://apply.workable.com/testco/jobs/view/SHARED0001.md"
+        raw_jobs = [
+            {"_detail_url": shared_url},
+            {"_detail_url": shared_url},
+        ]
+        mock_resp = MagicMock()
+        mock_resp.text = "# Engineer\n\n## Description\n\nWe use Go."
+        mock_resp.content = mock_resp.text.encode()
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        await workable._fetch_workable_descriptions(mock_client, raw_jobs)
+
+        assert mock_client.get.await_count == 1, (
+            "Duplicate _detail_url must not trigger duplicate HTTP requests"
+        )
+        # Only the first job gets description_html; the second is the duplicate and
+        # is skipped by the seen-set guard.
+        assert raw_jobs[0].get("description_html") == mock_resp.text
+
+    @pytest.mark.asyncio
+    async def test_missing_detail_url_skipped(self, workable: Extractor) -> None:
+        """A job with no _detail_url must be skipped without error."""
+        raw_job: dict = {"title": "Engineer", "_detail_url": None}
+        mock_client = AsyncMock()
+
+        await workable._fetch_workable_descriptions(mock_client, [raw_job])
+
+        mock_client.get.assert_not_awaited()
+        assert "description_html" not in raw_job
+
+
+# ─── Word-boundary safety in description_html ────────────────────────────────
+
+
+class TestWorkableDescriptionWordBoundaries:
+    """Verify that word-boundary rules still apply when matching description content."""
+
+    def test_rust_not_matched_in_trust(self, workable: Extractor) -> None:
+        raw = {
+            "title": "Software Developer",
+            "department": None,
+            "location": "Montreal, Canada",
+            "_employment_raw": None,
+            "_posted_raw": "2026-05-01",
+            "external_id": "WB000001",
+            "source_url": "https://apply.workable.com/testco/j/WB000001",
+            "description_html": "We trust our teams to ship quality software.",
+        }
+        result = workable._apply_extraction(raw, {"name": "TestCo", "slug": "testco"})
+        assert "Rust" not in result["tech_stack"], (
+            "'Rust' must not match 'trust' in the description — word-boundary still enforced."
+        )
+
+    def test_java_not_matched_in_javascript(self, workable: Extractor) -> None:
+        raw = {
+            "title": "Frontend Developer",
+            "department": None,
+            "location": "Montreal, Canada",
+            "_employment_raw": None,
+            "_posted_raw": "2026-05-01",
+            "external_id": "WB000002",
+            "source_url": "https://apply.workable.com/testco/j/WB000002",
+            "description_html": "You will work with JavaScript and TypeScript every day.",
+        }
+        result = workable._apply_extraction(raw, {"name": "TestCo", "slug": "testco"})
+        assert "Java" not in result["tech_stack"], "'Java' must not match inside 'JavaScript'."
+        assert "JavaScript" in result["tech_stack"]
+        assert "TypeScript" in result["tech_stack"]


### PR DESCRIPTION
## Fixes #56

### Contexte

L'endpoint liste de Workable (`jobs.md`) ne retourne pas les descriptions de poste. Layer 1 ne voyait que le **titre** pour les offres Workable — `tech_stack` était quasi-toujours vide sauf si la tech figurait dans le titre (ex : "Senior React Developer").

### Ce qui a changé

#### `pipeline/extractor.py`
- Nouveau `_WORKABLE_DETAIL_CONCURRENCY = 5`
- Nouveau hook `_enrich_raw_jobs()` — appelé dans `_fetch_company` entre le parse et l'extraction ; no-op pour Greenhouse/Lever
- Nouveau `_fetch_workable_descriptions()` — fetch concurrent (semaphore 5) de chaque `_detail_url` (`.md` endpoint) ; injecte le contenu Markdown dans `description_html` ; avale les erreurs HTTP/réseau par job ; ignore les URL relatives et les doublons

#### `specs/workable/extraction.xml` (v1 → v2)
- Ajout `<field name="description_html" from="description_html" ...>` — override le constant `null` si le fetch réussit
- `tech_stack` : `sources="title"` → `sources="title,description_html"`

#### `specs/workable/source.md`
- Nouvelle section **Detail-page fetch strategy** (pourquoi `.md` vs `/j/SHORTCODE`, concurrence, fallback)

#### Tests
- `tests/fixtures/workable_tecsys_sre_raw.json` — fixture Tecsys SRE dont les techs (AWS, Kubernetes, Python, Docker, Jenkins) n'apparaissent qu'en description
- `tests/test_workable_detail_fetch.py` — 13 tests : extraction, fallback, mocks async (inject / HTTP error / network error / duplicate URL / URL manquante), word-boundary safety

### Validation

```
pytest          → 182 passed (était 169)
ruff check .    → OK
python -m pipeline.extractor workable  → 65 jobs extraits
```

**Avant** : `Site Reliability Engineer` (Tecsys) → `tech_stack: []`
**Après** : `tech_stack: ['Python', 'Java', '.NET', 'AWS', 'Kubernetes', 'Jenkins']`

25 / 65 jobs Workable ont maintenant un `tech_stack` non-vide.

### Invariant Layer 1 préservé

Aucun appel LLM. Panne Anthropic → pipeline continue normalement.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)