### PR TITLE
fix: fetchStats() — replace client-side aggregation with COUNT query (#48)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -29,6 +29,19 @@ interface Stats {
   workplaceCounts: Record<string, number>;
 }
 
+// Shape returned by the get_homepage_stats() Supabase RPC.
+// All aggregation is done DB-side — no row data is transferred.
+interface DbStats {
+  new_today:        number;
+  company_count:    number;
+  remote_percent:   number;
+  source_counts:    Record<string, number>;
+  seniority_counts: Record<string, number>;
+  workplace_counts: Record<string, number>;
+  source_options:   string[];
+  tech_options:     string[];
+}
+
 async function fetchJobs(filters: SearchParams): Promise<{ jobs: Job[]; total: number }> {
   const page = Math.max(1, parseInt(filters.page ?? "1", 10));
   const from = (page - 1) * PAGE_SIZE;
@@ -53,52 +66,39 @@ async function fetchJobs(filters: SearchParams): Promise<{ jobs: Job[]; total: n
   return { jobs: (data ?? []) as Job[], total: count ?? 0 };
 }
 
+// Calls the get_homepage_stats() Supabase RPC.
+// All aggregation runs in the database — no job rows are transferred to the client.
+// See scripts/migrate_stats_rpc.sql for the SQL definition and how to apply it.
 async function fetchStats(): Promise<Stats> {
-  const { data } = await supabase
-    .from("active_qc_jobs")
-    .select("tech_stack, source, company, is_remote, seniority, first_seen_at");
+  const { data, error } = await supabase.rpc("get_homepage_stats");
 
-  const techSet       = new Set<string>();
-  const sourceSet     = new Set<string>();
-  const companySet    = new Set<string>();
-  const sourceCounts: Record<string, number>    = {};
-  const seniorityCounts: Record<string, number> = {};
-  const workplaceCounts: Record<string, number> = {};
-
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  let newTodayCount = 0;
-  let remoteOrHybrid = 0;
-
-  for (const row of data ?? []) {
-    for (const t of row.tech_stack ?? []) techSet.add(t);
-    if (row.source)  sourceSet.add(row.source);
-    if (row.company) companySet.add(row.company);
-
-    // Counts per filter value
-    if (row.source) sourceCounts[row.source] = (sourceCounts[row.source] ?? 0) + 1;
-    if (row.seniority) seniorityCounts[row.seniority] = (seniorityCounts[row.seniority] ?? 0) + 1;
-    const rk = row.is_remote === true ? "true" : row.is_remote === false ? "false" : "null";
-    workplaceCounts[rk] = (workplaceCounts[rk] ?? 0) + 1;
-
-    // New today
-    if (row.first_seen_at && new Date(row.first_seen_at) >= todayStart) newTodayCount++;
-
-    // Remote or hybrid (is_remote = true | null)
-    if (row.is_remote !== false) remoteOrHybrid++;
+  if (error) {
+    // Log the error but return safe zero-state so the page still renders.
+    // Filter sidebar will be empty; KPI strip will show zeros.
+    console.error("[fetchStats] RPC error:", error.message);
+    return {
+      techOptions:     [],
+      sourceOptions:   [],
+      companyCount:    0,
+      newTodayCount:   0,
+      remotePercent:   0,
+      sourceCounts:    {},
+      seniorityCounts: {},
+      workplaceCounts: {},
+    };
   }
 
-  const total = data?.length ?? 0;
+  const db = (data ?? {}) as DbStats;
 
   return {
-    techOptions:    [...techSet].sort(),
-    sourceOptions:  [...sourceSet].sort(),
-    companyCount:   companySet.size,
-    newTodayCount,
-    remotePercent:  total > 0 ? Math.round((remoteOrHybrid / total) * 100) : 0,
-    sourceCounts,
-    seniorityCounts,
-    workplaceCounts,
+    techOptions:     db.tech_options      ?? [],
+    sourceOptions:   db.source_options    ?? [],
+    companyCount:    db.company_count     ?? 0,
+    newTodayCount:   db.new_today         ?? 0,
+    remotePercent:   db.remote_percent    ?? 0,
+    sourceCounts:    db.source_counts     ?? {},
+    seniorityCounts: db.seniority_counts  ?? {},
+    workplaceCounts: db.workplace_counts  ?? {},
   };
 }
 

--- a/scripts/migrate_stats_rpc.sql
+++ b/scripts/migrate_stats_rpc.sql
@@ -1,0 +1,135 @@
+-- Jobs Radar QC — homepage stats RPC
+-- Creates get_homepage_stats(), a single DB-side call that replaces the previous
+-- client-side aggregation in fetchStats() (frontend/app/page.tsx, issue #48).
+-- Run after migrate.sql and migrate_enrichment.sql.
+-- Safe to re-run: CREATE OR REPLACE + idempotent GRANT.
+--
+-- ⚠  DATE SEMANTICS
+-- new_today uses CURRENT_DATE which is UTC midnight in Supabase.
+-- The previous fetchStats() used JS `new Date(); setHours(0, 0, 0, 0)` on the
+-- Next.js server (Vercel, UTC). Both resolve to UTC midnight — semantics match.
+-- If you ever deploy the Next.js server in a non-UTC timezone, prefer AT TIME ZONE.
+--
+-- ⚠  REMOTE / HYBRID DEFINITION
+-- is_remote = true  → remote (counts toward remote_percent)
+-- is_remote = null  → hybrid / unknown (counts toward remote_percent)
+-- is_remote = false → on-site (excluded from remote_percent)
+-- This matches the previous JS: `if (row.is_remote !== false) remoteOrHybrid++`
+--
+-- ⚠  HOW TO APPLY
+-- In Supabase SQL Editor: paste and run this file in one shot.
+-- In psql: \i scripts/migrate_stats_rpc.sql
+--
+-- VALIDATION (run in Supabase SQL Editor after applying)
+--   SELECT get_homepage_stats();
+-- Expected: a JSON object with new_today, company_count, remote_percent,
+--           source_counts, seniority_counts, workplace_counts,
+--           source_options, tech_options — all computed from active_qc_jobs.
+--
+-- NOTE ON TECH OPTIONS PERFORMANCE
+-- UNNEST over all active jobs is done entirely in the DB (no row transfer).
+-- At 10 000 jobs × avg 5 techs ≈ 50 000 values → DISTINCT collapses to
+-- ~100–200 unique tech strings. This is negligible compared to the previous
+-- approach (fetching all row data over the network).
+
+CREATE OR REPLACE FUNCTION get_homepage_stats()
+RETURNS json
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT json_build_object(
+
+    -- ── KPI strip ────────────────────────────────────────────────────────────
+
+    -- Jobs whose first_seen_at is on or after today's UTC midnight
+    'new_today', (
+      SELECT COUNT(*)
+      FROM   active_qc_jobs
+      WHERE  first_seen_at >= CURRENT_DATE
+    ),
+
+    -- Deduplicated company names
+    'company_count', (
+      SELECT COUNT(DISTINCT company)
+      FROM   active_qc_jobs
+    ),
+
+    -- Percentage of roles that are remote or hybrid (is_remote IS NOT FALSE)
+    'remote_percent', (
+      SELECT CASE
+        WHEN COUNT(*) = 0 THEN 0
+        ELSE ROUND(
+          100.0 * COUNT(*) FILTER (WHERE is_remote IS NOT FALSE)
+               / COUNT(*),
+          1
+        )
+      END
+      FROM active_qc_jobs
+    ),
+
+    -- ── Filter sidebar counts ────────────────────────────────────────────────
+
+    'source_counts', (
+      SELECT COALESCE(json_object_agg(source, cnt), '{}'::json)
+      FROM (
+        SELECT source, COUNT(*) AS cnt
+        FROM   active_qc_jobs
+        WHERE  source IS NOT NULL
+        GROUP  BY source
+      ) s
+    ),
+
+    'seniority_counts', (
+      SELECT COALESCE(json_object_agg(seniority, cnt), '{}'::json)
+      FROM (
+        SELECT seniority, COUNT(*) AS cnt
+        FROM   active_qc_jobs
+        WHERE  seniority IS NOT NULL
+        GROUP  BY seniority
+      ) s
+    ),
+
+    -- Keys are stringified to match FilterSidebar's 'true'/'false'/'null' convention
+    'workplace_counts', (
+      SELECT COALESCE(json_object_agg(is_remote_key, cnt), '{}'::json)
+      FROM (
+        SELECT
+          CASE
+            WHEN is_remote = true  THEN 'true'
+            WHEN is_remote = false THEN 'false'
+            ELSE                        'null'
+          END AS is_remote_key,
+          COUNT(*) AS cnt
+        FROM active_qc_jobs
+        GROUP BY 1
+      ) s
+    ),
+
+    -- ── Filter sidebar options ───────────────────────────────────────────────
+
+    'source_options', (
+      SELECT COALESCE(json_agg(src ORDER BY src), '[]'::json)
+      FROM (
+        SELECT DISTINCT source AS src
+        FROM   active_qc_jobs
+        WHERE  source IS NOT NULL
+      ) s
+    ),
+
+    -- All distinct technology names from the merged tech_stack column
+    'tech_options', (
+      SELECT COALESCE(json_agg(tech ORDER BY tech), '[]'::json)
+      FROM (
+        SELECT DISTINCT UNNEST(COALESCE(tech_stack, '{}')) AS tech
+        FROM   active_qc_jobs
+      ) t
+      WHERE tech IS NOT NULL
+        AND tech <> ''
+    )
+
+  );
+$$;
+
+-- Allow the frontend (anon key) and authenticated users to call this function.
+GRANT EXECUTE ON FUNCTION get_homepage_stats() TO anon, authenticated;


### PR DESCRIPTION
## Summary

Fixes #48.

`fetchStats()` previously selected **all rows** from `active_qc_jobs` (6 columns) and aggregated them in JavaScript. At scale this transfers megabytes of data over the network to compute 4 KPI numbers.

This PR replaces that with a single `supabase.rpc('get_homepage_stats')` call that computes everything in the database.

---

## What changed

- **`frontend/app/page.tsx`** — `fetchStats()` body replaced: 40-line JS aggregation loop → one RPC call. `DbStats` interface added for strict typing. Error fallback added (RPC failure → zero-state, page still renders).
- **`scripts/migrate_stats_rpc.sql`** — new idempotent migration creating `get_homepage_stats()` SQL function (`CREATE OR REPLACE`, `GRANT` to `anon` + `authenticated`).

---

## Stats behavior (unchanged semantics)

| KPI | DB computation |
|---|---|
| active roles | unchanged — `fetchJobs()` `count: exact` |
| new today | `COUNT(*) WHERE first_seen_at >= CURRENT_DATE` (UTC = same as old `setHours(0,0,0,0)` on Vercel) |
| companies | `COUNT(DISTINCT company)` |
| remote / hybrid % | `FILTER (WHERE is_remote IS NOT FALSE)` — preserves `is_remote !== false` logic; division-by-zero guarded |
| source / seniority / workplace counts | `GROUP BY` with `json_object_agg` |
| tech / source options | `DISTINCT UNNEST` / `DISTINCT source` — sorted JSON arrays |

---

## ⚠️ DB migration required before deploying

Apply `scripts/migrate_stats_rpc.sql` in the Supabase SQL Editor before merging to production:

```sql
-- paste scripts/migrate_stats_rpc.sql then validate:
SELECT get_homepage_stats();
```

Until applied, `fetchStats()` hits the error fallback and shows zero stats — the page still renders.

---

## Verification

- `tsc --noEmit` ✅ clean
- `eslint app/page.tsx --max-warnings=0` ✅ clean
- `fetchStats()` no longer calls `.from().select()` ✅ confirmed by grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)