### PR TITLE
feat: /api/radar — endpoint JSON + SVG curl-ready (embed README + partage) (#62)

### DIFF
--- a/frontend/app/api/radar/route.ts
+++ b/frontend/app/api/radar/route.ts
@@ -1,0 +1,124 @@
+/**
+ * GET /api/radar
+ *
+ * Returns radar data as JSON or as a standalone SVG image.
+ *
+ * Query parameters
+ * ────────────────
+ * format  (optional) "json" | "svg"   — default: "json"
+ * cats    (optional) comma-separated canonical category slugs
+ *                    — default: "languages,frontend,devops,data_ai"
+ *
+ * Examples
+ * ────────
+ * /api/radar?format=json&cats=languages,frontend,devops,data_ai
+ * /api/radar?format=svg&cats=languages,backend,testing,mobile
+ *
+ * ISR: revalidate every hour — matches /trends page cache TTL.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  CANONICAL,
+  DEFAULT_CATS,
+  parseCatsParam,
+  renderRadarSvg,
+} from "@/lib/radarHelpers";
+import { fetchRadarData } from "@/lib/radarData";
+
+export const revalidate = 3600;
+
+/** SVG returned when Supabase is unreachable or returns no data. */
+const SVG_ERROR = `<svg viewBox="0 0 560 480" xmlns="http://www.w3.org/2000/svg">
+  <rect width="560" height="480" fill="#0d1117"/>
+  <text x="280" y="240" font-family="sans-serif" font-size="14" text-anchor="middle" fill="#6e7681">
+    Radar data temporarily unavailable
+  </text>
+</svg>`;
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const { searchParams } = request.nextUrl;
+
+  /* ── Validate ?format= ──────────────────────────────────────────────── */
+  const format = searchParams.get("format") ?? "json";
+  if (format !== "json" && format !== "svg") {
+    return NextResponse.json(
+      { error: "Unsupported format. Accepted values: json, svg." },
+      { status: 400 },
+    );
+  }
+
+  /* ── Parse and validate ?cats= via shared helper ─────────────────────── */
+  const catsRaw = searchParams.get("cats") ?? undefined;
+  const cats = parseCatsParam(catsRaw, CANONICAL, DEFAULT_CATS);
+
+  /* ── Fetch radar data ───────────────────────────────────────────────── */
+  let fetchResult: Awaited<ReturnType<typeof fetchRadarData>>;
+  try {
+    fetchResult = await fetchRadarData("30d");
+  } catch {
+    if (format === "svg") {
+      return new NextResponse(SVG_ERROR, {
+        status: 500,
+        headers: svgHeaders(),
+      });
+    }
+    return NextResponse.json(
+      { error: "Failed to fetch radar data." },
+      { status: 500 },
+    );
+  }
+
+  const { techs: allTechs, jobCount, coMentions } = fetchResult;
+
+  /* ── SVG response ───────────────────────────────────────────────────── */
+  if (format === "svg") {
+    let svg: string;
+    try {
+      svg = renderRadarSvg(allTechs, cats);
+    } catch {
+      svg = SVG_ERROR;
+    }
+    return new NextResponse(svg, { status: 200, headers: svgHeaders() });
+  }
+
+  /* ── JSON response ──────────────────────────────────────────────────── */
+  // Filter techs to the selected categories only, preserving rank order.
+  const catSet = new Set(cats);
+  const filteredTechs = allTechs.filter((t) => catSet.has(t.category));
+
+  // Co-mentions restricted to techs in the selected categories.
+  const filteredCoMentions: Record<
+    string,
+    Array<{ name: string; pct: number }>
+  > = {};
+  for (const t of filteredTechs) {
+    filteredCoMentions[t.name] = coMentions[t.name] ?? [];
+  }
+
+  return NextResponse.json(
+    {
+      cats,
+      jobCount,
+      generatedAt: new Date().toISOString(),
+      techs: filteredTechs,
+      coMentions: filteredCoMentions,
+    },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+      },
+    },
+  );
+}
+
+/* ── Helpers ────────────────────────────────────────────────────────────── */
+
+function svgHeaders(): HeadersInit {
+  return {
+    "Content-Type": "image/svg+xml",
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+  };
+}

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -1,16 +1,20 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
-import { supabase } from "@/lib/supabase";
 import {
   CANONICAL,
   CATEGORY_LABELS,
   DEFAULT_CATS,
   type CatSlug,
-  buildTechToCatMap,
+  type TechRow,
   catToCssSlug,
   parseCatsParam,
 } from "@/lib/radarHelpers";
+import {
+  fetchRadarData,
+  parseWindow,
+  VALID_WINDOWS,
+} from "@/lib/radarData";
 import { RadarCategorySelector } from "@/components/RadarCategorySelector";
 import { RadarDownloadPanel } from "@/components/RadarDownloadPanel";
 
@@ -21,99 +25,6 @@ export const metadata: Metadata = {
 };
 
 export const revalidate = 3600;
-
-/* ── Reverse lookup: tech name → canonical category slug ──────────────── */
-const TECH_TO_CAT: Record<string, string> = buildTechToCatMap(CANONICAL);
-
-function getCategory(tech: string): string {
-  return TECH_TO_CAT[tech] ?? "other";
-}
-
-/* ── Data types ─────────────────────────────────────────────────────────── */
-interface TechRow {
-  name: string;
-  count: number;
-  rank: number;
-  /** Canonical category slug (e.g. "languages", "devops"). */
-  category: string;
-}
-
-/* ── Time-window options ─────────────────────────────────────────────── */
-const VALID_WINDOWS = ["7d", "30d", "90d", "all"] as const;
-type WindowOption = (typeof VALID_WINDOWS)[number];
-
-function parseWindow(raw: string | undefined): WindowOption {
-  return (VALID_WINDOWS as readonly string[]).includes(raw ?? "")
-    ? (raw as WindowOption)
-    : "30d";
-}
-
-function windowCutoff(w: WindowOption): string | null {
-  if (w === "all") return null;
-  const days = w === "7d" ? 7 : w === "30d" ? 30 : 90;
-  const d = new Date();
-  d.setDate(d.getDate() - days);
-  return d.toISOString().split("T")[0];
-}
-
-/* ── Fetch ──────────────────────────────────────────────────────────────── */
-async function fetchRadarData(window: WindowOption = "30d"): Promise<{
-  techs: TechRow[];
-  jobCount: number;
-  coMentions: Record<string, Array<{ name: string; pct: number }>>;
-}> {
-  const cutoff = windowCutoff(window);
-  let query = supabase.from("active_qc_jobs").select("tech_stack");
-  if (cutoff) query = query.gte("first_seen_at", cutoff);
-  const { data, error } = await query;
-
-  if (error || !data) return { techs: [], jobCount: 0, coMentions: {} };
-
-  // Count frequency per tech
-  const counts: Record<string, number> = {};
-  for (const row of data) {
-    for (const tech of (row.tech_stack as string[]) ?? []) {
-      counts[tech] = (counts[tech] ?? 0) + 1;
-    }
-  }
-
-  // Compute co-occurrences
-  const coOccurrence: Record<string, Record<string, number>> = {};
-  for (const row of data) {
-    const stack = (row.tech_stack as string[]) ?? [];
-    for (let i = 0; i < stack.length; i++) {
-      for (let j = i + 1; j < stack.length; j++) {
-        const a = stack[i], b = stack[j];
-        if (!coOccurrence[a]) coOccurrence[a] = {};
-        if (!coOccurrence[b]) coOccurrence[b] = {};
-        coOccurrence[a][b] = (coOccurrence[a][b] ?? 0) + 1;
-        coOccurrence[b][a] = (coOccurrence[b][a] ?? 0) + 1;
-      }
-    }
-  }
-
-  // Build ranked tech list (all techs, no global cap — radar caps per sector)
-  const all = Object.entries(counts)
-    .sort((a, b) => b[1] - a[1])
-    .map(([name, count], i) => ({
-      name,
-      count,
-      rank: i + 1,
-      category: getCategory(name),
-    }));
-
-  // Co-mentions as percentage of the tech's own count (top 8 per tech)
-  const coMentions: Record<string, Array<{ name: string; pct: number }>> = {};
-  for (const [tech, mentions] of Object.entries(coOccurrence)) {
-    const base = counts[tech] ?? 1;
-    coMentions[tech] = Object.entries(mentions)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 8)
-      .map(([name, c]) => ({ name, pct: Math.round((c / base) * 100) }));
-  }
-
-  return { techs: all, jobCount: data.length, coMentions };
-}
 
 /* ── Radar SVG ──────────────────────────────────────────────────────────── */
 function RadarChart({

--- a/frontend/components/RadarDownloadPanel.tsx
+++ b/frontend/components/RadarDownloadPanel.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 /**
- * RadarDownloadPanel — replaces the static curl card in the /trends side rail.
+ * RadarDownloadPanel — embed/API card in the /trends side rail.
  *
- * Shows dynamic curl commands for the currently selected radar categories.
- * Each line has a copy-to-clipboard button. The API endpoints (JSON + SVG)
- * will be live once issue #62 ships the /api/radar route.
+ * Shows dynamic curl commands and a direct SVG download link for the
+ * currently selected radar categories. Updates in real-time as the user
+ * swaps sectors via RadarCategorySelector.
+ *
+ * Both curl commands point to /api/radar (issue #62).
  */
 
 import { useState } from "react";
@@ -24,8 +26,10 @@ interface CopyState {
 
 export function RadarDownloadPanel({ cats }: Props) {
   const catStr = cats.join(",");
-  const jsonCmd = `curl ${BASE_URL}/api/radar.json?cats=${catStr}`;
+  const jsonCmd = `curl "${BASE_URL}/api/radar?format=json&cats=${catStr}"`;
   const svgCmd  = `curl "${BASE_URL}/api/radar?format=svg&cats=${catStr}"`;
+  // Relative path so the download link works in both dev and production.
+  const svgHref = `/api/radar?format=svg&cats=${catStr}`;
 
   const [copied, setCopied] = useState<CopyState>({ json: false, svg: false });
 
@@ -61,9 +65,35 @@ export function RadarDownloadPanel({ cats }: Props) {
         className="mt-2"
       />
 
+      {/* Download SVG link */}
+      <div className="mt-2 flex items-center justify-between">
+        <a
+          href={svgHref}
+          download="radar.svg"
+          style={{
+            color: "var(--accent)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 9,
+            textDecoration: "none",
+            opacity: 0.85,
+          }}
+        >
+          Download SVG
+        </a>
+        <span
+          style={{
+            color: "var(--ink-mute)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 9,
+          }}
+        >
+          embed-ready
+        </span>
+      </div>
+
       {/* Footer note */}
       <p
-        className="mt-2"
+        className="mt-1.5"
         style={{
           color: "var(--ink-mute)",
           fontFamily: "var(--font-mono)",
@@ -71,7 +101,7 @@ export function RadarDownloadPanel({ cats }: Props) {
           lineHeight: 1.5,
         }}
       >
-        MIT-licensed open data · ![radar](url) works in a GitHub README
+        MIT-licensed open data · works in a GitHub README
       </p>
     </div>
   );

--- a/frontend/lib/radarData.ts
+++ b/frontend/lib/radarData.ts
@@ -1,0 +1,104 @@
+/**
+ * radarData.ts — server-side data fetching for the Tech Stack Radar.
+ *
+ * Shared between:
+ *   - frontend/app/trends/page.tsx  (Server Component)
+ *   - frontend/app/api/radar/route.ts  (Route Handler)
+ *
+ * This module must never be imported by client components — it calls Supabase
+ * and may only run server-side.
+ */
+
+import { supabase } from "@/lib/supabase";
+import { buildTechToCatMap, CANONICAL, type TechRow } from "@/lib/radarHelpers";
+
+/* ── Reverse lookup: tech name → canonical category slug ──────────────── */
+const TECH_TO_CAT: Record<string, string> = buildTechToCatMap(CANONICAL);
+
+function getCategory(tech: string): string {
+  return TECH_TO_CAT[tech] ?? "other";
+}
+
+/* ── Time-window options ─────────────────────────────────────────────── */
+export const VALID_WINDOWS = ["7d", "30d", "90d", "all"] as const;
+export type WindowOption = (typeof VALID_WINDOWS)[number];
+
+export function parseWindow(raw: string | undefined): WindowOption {
+  return (VALID_WINDOWS as readonly string[]).includes(raw ?? "")
+    ? (raw as WindowOption)
+    : "30d";
+}
+
+function windowCutoff(w: WindowOption): string | null {
+  if (w === "all") return null;
+  const days = w === "7d" ? 7 : w === "30d" ? 30 : 90;
+  const d = new Date();
+  d.setDate(d.getDate() - days);
+  return d.toISOString().split("T")[0];
+}
+
+/* ── Fetch ──────────────────────────────────────────────────────────────── */
+/**
+ * Fetch all radar data from active_qc_jobs.
+ *
+ * Returns ALL technologies (not filtered by cats) ranked by frequency.
+ * Callers filter by selectedCats at the rendering/API response layer so
+ * both /trends and /api/radar operate on the same underlying dataset.
+ */
+export async function fetchRadarData(window: WindowOption = "30d"): Promise<{
+  techs: TechRow[];
+  jobCount: number;
+  coMentions: Record<string, Array<{ name: string; pct: number }>>;
+}> {
+  const cutoff = windowCutoff(window);
+  let query = supabase.from("active_qc_jobs").select("tech_stack");
+  if (cutoff) query = query.gte("first_seen_at", cutoff);
+  const { data, error } = await query;
+
+  if (error || !data) return { techs: [], jobCount: 0, coMentions: {} };
+
+  // Count frequency per tech
+  const counts: Record<string, number> = {};
+  for (const row of data) {
+    for (const tech of (row.tech_stack as string[]) ?? []) {
+      counts[tech] = (counts[tech] ?? 0) + 1;
+    }
+  }
+
+  // Compute co-occurrences
+  const coOccurrence: Record<string, Record<string, number>> = {};
+  for (const row of data) {
+    const stack = (row.tech_stack as string[]) ?? [];
+    for (let i = 0; i < stack.length; i++) {
+      for (let j = i + 1; j < stack.length; j++) {
+        const a = stack[i], b = stack[j];
+        if (!coOccurrence[a]) coOccurrence[a] = {};
+        if (!coOccurrence[b]) coOccurrence[b] = {};
+        coOccurrence[a][b] = (coOccurrence[a][b] ?? 0) + 1;
+        coOccurrence[b][a] = (coOccurrence[b][a] ?? 0) + 1;
+      }
+    }
+  }
+
+  // Build ranked tech list (all techs, no global cap — radar caps per sector)
+  const all = Object.entries(counts)
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, count], i) => ({
+      name,
+      count,
+      rank: i + 1,
+      category: getCategory(name),
+    }));
+
+  // Co-mentions as percentage of the tech's own count (top 8 per tech)
+  const coMentions: Record<string, Array<{ name: string; pct: number }>> = {};
+  for (const [tech, mentions] of Object.entries(coOccurrence)) {
+    const base = counts[tech] ?? 1;
+    coMentions[tech] = Object.entries(mentions)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 8)
+      .map(([name, c]) => ({ name, pct: Math.round((c / base) * 100) }));
+  }
+
+  return { techs: all, jobCount: data.length, coMentions };
+}

--- a/frontend/lib/radarHelpers.ts
+++ b/frontend/lib/radarHelpers.ts
@@ -6,6 +6,15 @@
  * the ALL_CAT_SLUGS / CATEGORY_LABELS constants accordingly.
  */
 
+/** A single ranked technology entry returned by fetchRadarData. */
+export interface TechRow {
+  name: string;
+  count: number;
+  rank: number;
+  /** Canonical category slug (e.g. "languages", "devops"). */
+  category: string;
+}
+
 export interface CanonicalStack {
   version: string;
   categories: Record<string, string[]>;
@@ -202,4 +211,186 @@ export function buildTechToCatMap(
     }
   }
   return map;
+}
+
+// ---------------------------------------------------------------------------
+// Standalone SVG rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Hardcoded hex equivalents of the CSS custom properties.
+ * CSS vars (--cat-*) cannot be resolved in standalone SVGs used as <img> or
+ * embedded in GitHub READMEs. Values are derived from globals.css:
+ *   oklch(0.55 0.18 <H>) converted to sRGB hex.
+ */
+export const CAT_COLORS: Record<string, string> = {
+  languages:   "#4b73c4",  // oklch(0.55 0.18 252) — blue
+  frontend:    "#1b9e79",  // oklch(0.55 0.18 160) — teal
+  backend:     "#1b7d9e",  // oklch(0.55 0.18 200) — cyan
+  databases:   "#7949cc",  // oklch(0.55 0.18 295) — violet
+  cloud:       "#b89020",  // oklch(0.55 0.18  55) — amber
+  devops:      "#cc6620",  // oklch(0.55 0.18  30) — orange
+  data_ai:     "#cc5245",  // oklch(0.55 0.18  20) — coral
+  mobile:      "#cc3d70",  // oklch(0.55 0.18 330) — rose
+  testing:     "#38a847",  // oklch(0.55 0.18 130) — green
+  ai_concepts: "#849920",  // oklch(0.55 0.18  85) — lime
+};
+
+/** Escape a string for safe insertion into SVG text/attribute content. */
+function escSvg(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+/**
+ * Render a standalone SVG string for the radar.
+ *
+ * Mirrors the RadarChart JSX component in trends/page.tsx but returns a
+ * self-contained SVG string with hardcoded colors (no CSS variables) so
+ * it can be embedded in a GitHub README or served via /api/radar?format=svg.
+ *
+ * viewBox: "0 0 560 480" · CX=280, CY=240, R=200 · 4 rings · 4 sectors
+ */
+export function renderRadarSvg(
+  allTechs: TechRow[],
+  selectedCats: string[],
+): string {
+  const CX = 280, CY = 240, R = 200;
+  const RINGS = [0.95, 0.68, 0.42, 0.18];
+  const RING_LABELS = ["top 5", "top 10", "top 20", "long tail"];
+  const TOP5 = new Set(allTechs.slice(0, 5).map((t) => t.name));
+
+  /* ── Group techs by sector, capped at 8 per sector ─────────────────── */
+  const byCat: Record<string, TechRow[]> = {};
+  for (const cat of selectedCats) byCat[cat] = [];
+  for (const t of allTechs) {
+    const arr = byCat[t.category];
+    if (arr && arr.length < 8) arr.push(t);
+  }
+
+  /* ── Polar placement ────────────────────────────────────────────────── */
+  interface Placed {
+    tech: TechRow;
+    x: number;
+    y: number;
+    size: number;
+    isTop5: boolean;
+    labelSide: "right" | "left";
+    color: string;
+  }
+
+  const placed: Placed[] = [];
+  selectedCats.forEach((cat, catIdx) => {
+    const arr = byCat[cat] ?? [];
+    const sectorAngle = (Math.PI * 2) / selectedCats.length;
+    arr.forEach((tech, i) => {
+      const angle =
+        -Math.PI / 2 +
+        catIdx * sectorAngle +
+        (sectorAngle * (i + 1)) / (arr.length + 1);
+      const rankFrac = tech.rank / Math.max(1, allTechs.length);
+      const r = R * (0.16 + 0.76 * Math.min(1, rankFrac * 1.8));
+      const x = CX + Math.cos(angle) * r;
+      const y = CY + Math.sin(angle) * r;
+      const size = Math.max(6, Math.min(20, Math.sqrt(tech.count) * 1.3));
+      const isTop5 = TOP5.has(tech.name);
+      const labelSide: "right" | "left" = x > CX ? "right" : "left";
+      const color = CAT_COLORS[cat] ?? "#888888";
+      placed.push({ tech, x, y, size, isTop5, labelSide, color });
+    });
+  });
+
+  /* ── Build SVG string ───────────────────────────────────────────────── */
+  const n = (v: number, d = 1) => v.toFixed(d);
+  const parts: string[] = [];
+
+  parts.push(
+    `<svg viewBox="0 0 560 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tech Stack Radar — Jobs Radar /qc">`,
+  );
+  parts.push(`<title>Tech Stack Radar — Jobs Radar /qc</title>`);
+  parts.push(
+    `<desc>Radial chart showing ${placed.length} technologies grouped into ${selectedCats.length} sectors: ` +
+      `${selectedCats.map((c) => CATEGORY_LABELS[c as CatSlug] ?? c).join(", ")}. ` +
+      `Bubble size represents posting count; proximity to center represents overall rank.</desc>`,
+  );
+
+  // Background
+  parts.push(`<rect width="560" height="480" fill="#0d1117"/>`);
+
+  // Concentric rings
+  for (let i = 0; i < RINGS.length; i++) {
+    const k = RINGS[i];
+    parts.push(
+      `<circle cx="${CX}" cy="${CY}" r="${n(R * k, 1)}" fill="none" stroke="#21262d" stroke-dasharray="3 5" stroke-width="1"/>`,
+    );
+    parts.push(
+      `<text x="${n(CX + R * k + 5, 1)}" y="${n(CY - 5, 1)}" font-family="monospace" font-size="9" fill="#6e7681">${escSvg(RING_LABELS[i])}</text>`,
+    );
+  }
+
+  // Sector divider lines
+  selectedCats.forEach((_, i) => {
+    const sectorAngle = (Math.PI * 2) / selectedCats.length;
+    const a0 = -Math.PI / 2 + i * sectorAngle;
+    parts.push(
+      `<line x1="${CX}" y1="${CY}" x2="${n(CX + Math.cos(a0) * R)}" y2="${n(CY + Math.sin(a0) * R)}" stroke="#21262d" stroke-width="1"/>`,
+    );
+  });
+
+  // Sector labels
+  selectedCats.forEach((cat, i) => {
+    const sectorAngle = (Math.PI * 2) / selectedCats.length;
+    const am = -Math.PI / 2 + i * sectorAngle + sectorAngle / 2;
+    const lx = CX + Math.cos(am) * (R + 26);
+    const ly = CY + Math.sin(am) * (R + 26);
+    const color = CAT_COLORS[cat] ?? "#888888";
+    const label = CATEGORY_LABELS[cat as CatSlug] ?? cat;
+    parts.push(
+      `<text x="${n(lx)}" y="${n(ly)}" font-family="sans-serif" font-size="11" font-weight="600" text-anchor="middle" fill="${escSvg(color)}">${escSvg(label)}</text>`,
+    );
+  });
+
+  // Decorative sweep line at -32°
+  parts.push(
+    `<line x1="${CX}" y1="${CY}" x2="${CX + R}" y2="${CY}" stroke="#4b73c4" stroke-width="1.25" stroke-dasharray="2 5" opacity="0.45" transform="rotate(-32 ${CX} ${CY})"/>`,
+  );
+
+  // Center dot + ring
+  parts.push(`<circle cx="${CX}" cy="${CY}" r="5" fill="#4b73c4"/>`);
+  parts.push(
+    `<circle cx="${CX}" cy="${CY}" r="13" fill="none" stroke="#4b73c4" stroke-width="1"/>`,
+  );
+
+  // Bubbles
+  for (const { tech, x, y, size, isTop5, labelSide, color } of placed) {
+    // Top-5: solid fill; others: ~35% opacity (hex 59 ≈ 35% of 255)
+    const fill = isTop5 ? color : `${color}59`;
+    const labelX = labelSide === "right" ? x + size + 4 : x - size - 4;
+    const anchor = labelSide === "right" ? "start" : "end";
+    parts.push(
+      `<circle cx="${n(x)}" cy="${n(y)}" r="${n(size)}" fill="${escSvg(fill)}" stroke="#21262d" stroke-width="1">` +
+        `<title>${escSvg(tech.name)} — ${tech.count} roles (rank #${tech.rank})</title>` +
+        `</circle>`,
+    );
+    if (isTop5) {
+      parts.push(
+        `<text x="${n(labelX)}" y="${n(y + 3)}" font-family="sans-serif" font-size="10.5" font-weight="600" text-anchor="${anchor}" fill="#c9d1d9">${escSvg(tech.name)}</text>`,
+      );
+      parts.push(
+        `<text x="${n(labelX)}" y="${n(y + 14)}" font-family="monospace" font-size="8.5" text-anchor="${anchor}" fill="#6e7681">${tech.count}</text>`,
+      );
+    }
+  }
+
+  // Legend
+  parts.push(
+    `<text x="16" y="470" font-family="monospace" font-size="9" fill="#6e7681">size = job count · proximity to center = rank · jobs-radar-qc.dev/trends</text>`,
+  );
+
+  parts.push(`</svg>`);
+  return parts.join("\n");
 }


### PR DESCRIPTION
Closes #62

## What changed

### New files
- `frontend/app/api/radar/route.ts` — Route Handler for `GET /api/radar`
- `frontend/lib/radarData.ts` — Extracted shared data-fetch layer (was embedded in `page.tsx`)

### Modified files
- `frontend/lib/radarHelpers.ts` — Added `TechRow` interface, `CAT_COLORS` map, and `renderRadarSvg()` pure helper
- `frontend/app/trends/page.tsx` — Refactored to import from `radarData.ts`; removed ~80 lines of duplicate fetch logic
- `frontend/components/RadarDownloadPanel.tsx` — Fixed JSON curl URL; added Download SVG anchor

---

## API endpoints

```bash
# JSON (default)
curl "https://jobs-radar-qc.dev/api/radar?format=json&cats=languages,frontend,devops,data_ai"

# SVG (embed-ready)
curl "https://jobs-radar-qc.dev/api/radar?format=svg&cats=languages,backend,testing,mobile" > radar.svg

# Invalid format → 400
curl "https://jobs-radar-qc.dev/api/radar?format=bad"
# → {"error":"Unsupported format. Accepted values: json, svg."}

# Bad cats → normalized to defaults silently
curl "https://jobs-radar-qc.dev/api/radar?cats=bad,bad,bad"
# → cats: ["languages","frontend","devops","data_ai"]
```

---

## Verification

**TypeScript:** `tsc --noEmit` — exit 0, zero errors  
**Lint:** `eslint` — zero errors, zero warnings  
**Build:** `next build` — compiled successfully, `/api/radar ƒ (Dynamic)`

**Endpoint checks (dev server):**
- `/api/radar?format=json&cats=languages,frontend,devops,data_ai` → 200, correct JSON shape with `cats`, `jobCount`, `generatedAt`, ranked `techs[]`, `coMentions{}`
- `/api/radar?format=svg&cats=languages,backend,testing,mobile` → 200, `image/svg+xml`, 4 sector labels, top-5 labels, `access-control-allow-origin: *`
- `/api/radar?format=bad` → 400 JSON error
- `/api/radar?cats=bad,bad,bad` → normalized to defaults
- `/trends` → unchanged, download panel URLs updated (`?format=json&cats=` and `?format=svg&cats=`)

---

## Design decisions

- `fetchRadarData` extracted to `lib/radarData.ts` so `/trends` and `/api/radar` share identical data pipeline — category behavior cannot drift between UI and API
- `renderRadarSvg` in `radarHelpers.ts` mirrors the `RadarChart` JSX component exactly (same polar math, same ring/sector layout, same size formula)
- `CAT_COLORS` hardcodes hex equivalents of the CSS oklch() custom properties — necessary because CSS variables cannot be resolved in standalone SVGs served as `<img>` or embedded in GitHub READMEs
- `export const revalidate = 3600` matches the `/trends` ISR TTL
- Scope strictly limited to #62 — no role segmentation (#63), no snapshot logic (#26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)