### PR TITLE
feat: freshness timestamp on KPI strip (issue #53)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -27,6 +27,7 @@ interface Stats {
   sourceCounts: Record<string, number>;
   seniorityCounts: Record<string, number>;
   workplaceCounts: Record<string, number>;
+  lastUpdated: string | null;
 }
 
 // Shape returned by the get_homepage_stats() Supabase RPC.
@@ -40,6 +41,7 @@ interface DbStats {
   workplace_counts: Record<string, number>;
   source_options:   string[];
   tech_options:     string[];
+  last_updated:     string | null;
 }
 
 async function fetchJobs(filters: SearchParams): Promise<{ jobs: Job[]; total: number }> {
@@ -85,6 +87,7 @@ async function fetchStats(): Promise<Stats> {
       sourceCounts:    {},
       seniorityCounts: {},
       workplaceCounts: {},
+      lastUpdated:     null,
     };
   }
 
@@ -99,6 +102,7 @@ async function fetchStats(): Promise<Stats> {
     sourceCounts:    db.source_counts     ?? {},
     seniorityCounts: db.seniority_counts  ?? {},
     workplaceCounts: db.workplace_counts  ?? {},
+    lastUpdated:     db.last_updated      ?? null,
   };
 }
 
@@ -183,6 +187,7 @@ export default async function Page({
             companies={stats.companyCount}
             remotePercent={stats.remotePercent}
             hasFilters={hasFilters}
+            lastUpdated={stats.lastUpdated}
           />
         </div>
 

--- a/frontend/components/KpiStrip.tsx
+++ b/frontend/components/KpiStrip.tsx
@@ -4,6 +4,29 @@ interface KpiStripProps {
   companies: number;
   remotePercent: number;
   hasFilters: boolean;
+  lastUpdated?: string | null;
+}
+
+/** Converts an ISO timestamp to a human-readable relative string, server-side.
+ *  Returns the formatted text and whether the timestamp is considered stale (> 25h). */
+function formatRelativeTime(isoString: string): { text: string; stale: boolean } {
+  const diffMs      = Date.now() - new Date(isoString).getTime();
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  const diffHours   = Math.floor(diffMs / 3_600_000);
+  const diffDays    = Math.floor(diffMs / 86_400_000);
+
+  const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+  let text: string;
+  if (diffMinutes < 60) {
+    text = rtf.format(-diffMinutes, "minute");
+  } else if (diffHours < 24) {
+    text = rtf.format(-diffHours, "hour");
+  } else {
+    text = rtf.format(-diffDays, "day");
+  }
+
+  return { text, stale: diffHours >= 25 };
 }
 
 interface CardProps {
@@ -54,33 +77,66 @@ export default function KpiStrip({
   companies,
   remotePercent,
   hasFilters,
+  lastUpdated,
 }: KpiStripProps) {
+  const freshness = lastUpdated ? formatRelativeTime(lastUpdated) : null;
+
   return (
-    <div className="flex items-stretch gap-2">
-      {/* Desktop: 4 cards. Mobile: first 3 only (hidden via CSS) */}
-      <KpiCard
-        label="active"
-        value={activeRoles}
-        sub={hasFilters ? "matching" : "roles"}
-      />
-      <KpiCard
-        label="new today"
-        value={newToday}
-        sub="last 24 h"
-      />
-      <KpiCard
-        label="companies"
-        value={companies}
-        sub="tracked"
-      />
-      {/* Hidden on mobile — not critical at small screen */}
-      <div className="hidden sm:block" style={{ flex: "1 1 0" }}>
+    <div>
+      <div className="flex items-stretch gap-2">
+        {/* Desktop: 4 cards. Mobile: first 3 only (hidden via CSS) */}
         <KpiCard
-          label="remote / hybrid"
-          value={`${remotePercent}%`}
-          sub="of active roles"
+          label="active"
+          value={activeRoles}
+          sub={hasFilters ? "matching" : "roles"}
         />
+        <KpiCard
+          label="new today"
+          value={newToday}
+          sub="last 24 h"
+        />
+        <KpiCard
+          label="companies"
+          value={companies}
+          sub="tracked"
+        />
+        {/* Hidden on mobile — not critical at small screen */}
+        <div className="hidden sm:block" style={{ flex: "1 1 0" }}>
+          <KpiCard
+            label="remote / hybrid"
+            value={`${remotePercent}%`}
+            sub="of active roles"
+          />
+        </div>
       </div>
+
+      {/* Freshness indicator — shown below the KPI row */}
+      {freshness && (
+        <div
+          className="mt-1.5 flex items-center gap-1.5"
+          style={{
+            color: freshness.stale ? "#d97706" : "var(--ink-mute)",
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              display: "inline-block",
+              width: 5,
+              height: 5,
+              borderRadius: "50%",
+              background: freshness.stale ? "#d97706" : "#22c55e",
+              flexShrink: 0,
+            }}
+          />
+          <span>
+            {freshness.stale ? "Last updated" : "Updated"} {freshness.text}
+            {freshness.stale && " · pipeline may be delayed"}
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/scripts/migrate_stats_rpc.sql
+++ b/scripts/migrate_stats_rpc.sql
@@ -24,7 +24,7 @@
 --   SELECT get_homepage_stats();
 -- Expected: a JSON object with new_today, company_count, remote_percent,
 --           source_counts, seniority_counts, workplace_counts,
---           source_options, tech_options — all computed from active_qc_jobs.
+--           source_options, tech_options, last_updated — all computed from active_qc_jobs.
 --
 -- NOTE ON TECH OPTIONS PERFORMANCE
 -- UNNEST over all active jobs is done entirely in the DB (no row transfer).
@@ -126,6 +126,13 @@ AS $$
       ) t
       WHERE tech IS NOT NULL
         AND tech <> ''
+    ),
+
+    -- Timestamp of the most recently added job — used for the freshness indicator
+    -- in the KPI strip. If > 25h old, the UI shows an amber warning.
+    'last_updated', (
+      SELECT MAX(first_seen_at)
+      FROM   active_qc_jobs
     )
 
   );


### PR DESCRIPTION
## Summary

Adds a small freshness indicator below the KPI cards so users can see when the pipeline last ran.

## What changed

### `scripts/migrate_stats_rpc.sql`
Added `last_updated` to the `get_homepage_stats()` RPC — a single `MAX(first_seen_at)` scalar subquery, zero performance impact.

### `frontend/app/page.tsx`
Threaded `lastUpdated: string | null` through `DbStats` → `Stats` → `fetchStats()` → `<KpiStrip>`.

### `frontend/components/KpiStrip.tsx`
- Added `formatRelativeTime()` helper using `Intl.RelativeTimeFormat` (server-side, no library)
- Renders a dot + text line below the cards:
  - 🟢 `Updated 2h ago` — pipeline is on schedule
  - 🟡 `Last updated 26h ago · pipeline may be delayed` — amber when > 25h

## ⚠️ Manual step required

Run `scripts/migrate_stats_rpc.sql` in Supabase SQL Editor to deploy the updated RPC. The function uses `CREATE OR REPLACE` — safe to re-run.

```sql
SELECT get_homepage_stats();
-- should now include "last_updated": "2026-05-25T08:14:00+00:00"
```

## Checklist
- [x] TypeScript clean (`npm run build` → 2.2s, no errors)
- [x] No new dependencies
- [x] Server Component only — no `use client` added
- [x] Gracefully handles `lastUpdated = null` (indicator simply hidden)

Closes #53

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)