### PR TITLE
fix: replace hardcoded hex in KPI freshness indicator with design tokens

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -39,6 +39,9 @@
   --cat-testing:     oklch(0.55 0.18 130);  /* green                      */
   --cat-ai-concepts: oklch(0.55 0.18 85);   /* lime                       */
 
+  /* Status / freshness */
+  --warning:     oklch(0.72 0.15 60);   /* #d97706 amber — stale pipeline indicator */
+
   /* Kanban column accent colors */
   --col-applied: #b8860b;   /* amber — Applied column header dot */
 

--- a/frontend/components/KpiStrip.tsx
+++ b/frontend/components/KpiStrip.tsx
@@ -115,7 +115,7 @@ export default function KpiStrip({
         <div
           className="mt-1.5 flex items-center gap-1.5"
           style={{
-            color: freshness.stale ? "#d97706" : "var(--ink-mute)",
+            color: freshness.stale ? "var(--warning)" : "var(--ink-mute)",
             fontFamily: "var(--font-mono)",
             fontSize: 10,
           }}
@@ -127,7 +127,7 @@ export default function KpiStrip({
               width: 5,
               height: 5,
               borderRadius: "50%",
-              background: freshness.stale ? "#d97706" : "#22c55e",
+              background: freshness.stale ? "var(--warning)" : "var(--accent)",
               flexShrink: 0,
             }}
           />


### PR DESCRIPTION
## Summary

Follow-up to PR #77 (issue #53 — KPI freshness timestamp).

The freshness indicator landed with two hardcoded hex values that violate the project's design-token rule (*no hardcoded colors outside `tokens.css`* per `agents/ux-ui_agent.md`):

| Location | Was | Now |
|---|---|---|
| fresh dot (`background`) | `#22c55e` (green) | `var(--accent)` (brand blue — matches spec) |
| stale text/dot (`color` + `background`) | `#d97706` (amber) | `var(--warning)` (new token) |

## What changed

### `frontend/app/globals.css`
Added `--warning: oklch(0.72 0.15 60)` — the amber pipeline-delay color, now a proper design token.

### `frontend/components/KpiStrip.tsx`
Replaced both hardcoded hex literals with their token equivalents. No behavioral change.

## Verification

```bash
cd frontend
npx tsc --noEmit   # ✅ clean
npm run lint        # ✅ clean
```

Visual: freshness dot is now brand blue (fresh) or amber token (stale), matching the `ux-ui_agent.md` spec that lists the fresh dot under `--accent` usage.

## Related
- Closes follow-up on #53
- PR #77 (freshness feature) · issue #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)