### PR TITLE
feat: add route progress loading states

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -136,3 +136,29 @@ body {
   outline-offset: -3px;
   border-radius: 4px;
 }
+
+/* ── Route loading — indeterminate progress bar ──────────────────────────
+ * Used by app/loading.tsx, app/trends/loading.tsx, app/saved/loading.tsx.
+ * The animation slides the accent-filled block across the 2 px track.
+ * The global prefers-reduced-motion block above already freezes all
+ * animations (animation-duration: 0.01ms; iteration-count: 1), which
+ * would snap the bar off-screen.  The rule below overrides that for
+ * .route-progress-fill specifically, making it a static partial fill
+ * instead of invisible.
+ * ─────────────────────────────────────────────────────────────────────── */
+@keyframes route-progress {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(300%); }
+}
+
+.route-progress-fill {
+  animation: route-progress 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .route-progress-fill {
+    animation: none !important;
+    transform: none !important;
+    width: 30% !important; /* static partial fill — visible but not moving */
+  }
+}

--- a/frontend/app/loading.tsx
+++ b/frontend/app/loading.tsx
@@ -1,0 +1,16 @@
+/**
+ * app/loading.tsx — route-level loading state for "/"
+ *
+ * Next.js App Router renders this file in place of page.tsx while the
+ * async Server Component fetches data (Supabase jobs + stats RPC).
+ * The layout shell (TopNav + BottomTabBar) is already visible from
+ * layout.tsx — no need to duplicate chrome here.
+ *
+ * Renders: blank content area + 2 px indeterminate accent progress bar.
+ * No skeleton loaders, no pulsing placeholders. See §7 of ux-ui_agent.md.
+ */
+import RouteLoading from "@/components/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/frontend/app/saved/loading.tsx
+++ b/frontend/app/saved/loading.tsx
@@ -1,0 +1,17 @@
+/**
+ * app/saved/loading.tsx — route-level loading state for "/saved"
+ *
+ * SavedPage is a thin wrapper around SavedPageClient ("use client").
+ * Although the server-side render itself is fast (no data fetching),
+ * a loading.tsx is added for consistency and to cover the brief hydration
+ * window on slower devices / connections.  The layout shell
+ * (TopNav + BottomTabBar) is already visible from layout.tsx.
+ *
+ * Renders: blank content area + 2 px indeterminate accent progress bar.
+ * No skeleton Kanban columns, no ghost cards. See §7 of ux-ui_agent.md.
+ */
+import RouteLoading from "@/components/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/frontend/app/trends/loading.tsx
+++ b/frontend/app/trends/loading.tsx
@@ -1,0 +1,15 @@
+/**
+ * app/trends/loading.tsx — route-level loading state for "/trends"
+ *
+ * Shown while TrendsPage fetches radar data from Supabase (revalidate = 3600,
+ * so a cache miss triggers a full server render).  The layout shell
+ * (TopNav + BottomTabBar) is already visible from layout.tsx.
+ *
+ * Renders: blank content area + 2 px indeterminate accent progress bar.
+ * No skeleton loaders, no fake chart placeholders. See §7 of ux-ui_agent.md.
+ */
+import RouteLoading from "@/components/RouteLoading";
+
+export default function Loading() {
+  return <RouteLoading />;
+}

--- a/frontend/components/RouteLoading.tsx
+++ b/frontend/components/RouteLoading.tsx
@@ -1,0 +1,72 @@
+/**
+ * RouteLoading
+ *
+ * Shared loading UI consumed by all three route loading.tsx files:
+ *   app/loading.tsx            → /
+ *   app/trends/loading.tsx     → /trends
+ *   app/saved/loading.tsx      → /saved
+ *
+ * In Next.js App Router, loading.tsx is rendered INSIDE layout.tsx,
+ * which means the full shell (TopNav header + BottomTabBar) is already
+ * visible on-screen — this component only needs to fill the {children}
+ * slot with:
+ *   1. A blank content area at var(--bg).
+ *   2. A thin (2 px ≤ 3 px max) indeterminate progress bar at var(--accent)
+ *      positioned at the very top of the content area.
+ *
+ * Animation:
+ *   - Pure CSS keyframes defined in globals.css (.route-progress-fill).
+ *   - No third-party library, no animate-pulse, no skeleton placeholders.
+ *   - Stops (becomes a static 30 % fill) under prefers-reduced-motion.
+ *
+ * Accessibility:
+ *   - role="progressbar" on the track element.
+ *   - aria-label provides a terse description for screen readers.
+ *   - The animated inner fill carries aria-hidden — its parent conveys meaning.
+ *   - No live-region announcements (aria-live omitted to avoid noise on
+ *     fast transitions).
+ */
+export default function RouteLoading() {
+  return (
+    <div
+      /*
+       * flex-1: grows to fill the space between the sticky header and
+       * footer in layout.tsx's flex-col body.
+       * position: relative: provides the containing block for the
+       * absolutely-positioned progress bar track.
+       */
+      className="flex-1"
+      style={{ background: "var(--bg)", position: "relative" }}
+    >
+      {/* ── Progress bar track ──────────────────────────────────────────── */}
+      <div
+        role="progressbar"
+        aria-label="Loading page"
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 2,           /* 2 px — well within the ≤ 3 px spec */
+          overflow: "hidden",
+          background: "transparent",
+        }}
+      >
+        {/* Accent fill — animated via .route-progress-fill in globals.css */}
+        <div
+          aria-hidden="true"
+          className="route-progress-fill"
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            height: "100%",
+            width: "40%",
+            background: "var(--accent)",
+            borderRadius: 1,
+          }}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes the blank-page flash on `/`, `/trends`, and `/saved` during slow route transitions by adding Next.js App Router `loading.tsx` files.

### How it works

In App Router, `loading.tsx` files render inside `layout.tsx`'s `{children}` slot — meaning the **full shell (TopNav + BottomTabBar) is already visible** without any duplication. Each loading file only needs to fill the content area.

All three routes share a single `RouteLoading` component that renders:
1. A blank content area (`var(--bg)`)
2. A **2 px** indeterminate progress bar using `var(--accent)` (CSS-only, no library)

### What changed

- `components/RouteLoading.tsx` — shared Server Component: blank `--bg` fill + 2 px accent progress bar, `role="progressbar"`, `aria-label`
- `app/loading.tsx` — route loading for `/`
- `app/trends/loading.tsx` — route loading for `/trends`
- `app/saved/loading.tsx` — route loading for `/saved`
- `app/globals.css` — `@keyframes route-progress` + `.route-progress-fill` class; `prefers-reduced-motion` override makes the bar a static 30% fill instead of animating

### What this is NOT

No skeleton loaders, no pulsing cards, no ghost columns, no fake chart placeholders, no third-party libraries (NProgress, etc.) — per §7 of `agents/ux-ui_agent.md`.

---

## Verification commands

```bash
cd frontend
npm run lint      # ✓ no errors
npm run build     # ✓ TypeScript + Turbopack build passes
```

## Manual route checks

| Route | Check |
|-------|-------|
| `/` | Throttle to Slow 3G in DevTools → navigate → see accent bar below TopNav, no blank flash |
| `/trends` | Same — bar appears while radar data loads |
| `/saved` | Bar appears briefly; TopNav + BottomTabBar always visible |
| 375px mobile | BottomTabBar visible during transition on all routes |
| Reduced motion | Bar is static 30% fill (no animation) under `prefers-reduced-motion: reduce` |

---

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)