### PR TITLE
feat: add dark mode token layer

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -45,6 +45,9 @@
   /* Kanban column accent colors */
   --col-applied: #b8860b;   /* amber — Applied column header dot */
 
+  /* On-accent — white text for colored/accent chip backgrounds */
+  --on-accent: oklch(1 0 0);
+
   /* Fonts (set by Next.js) */
   --font-sans: var(--font-inter);
   --font-mono: var(--font-jetbrains-mono);
@@ -53,6 +56,51 @@
 @theme inline {
   --font-sans: var(--font-inter);
   --font-mono: var(--font-jetbrains-mono);
+}
+
+/* ── Dark mode token layer ────────────────────────────────────────────── */
+/*
+ * Overrides light-theme tokens for OS-level dark mode.
+ * No JS, no localStorage — pure CSS media query.
+ * --accent and --on-accent are unchanged (blue + white remain correct in dark).
+ * Category tokens (--cat-*) stay the same — oklch(0.55 0.18 …) reads fine
+ * on dark backgrounds and matches radar bubble fills.
+ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    /* Backgrounds — cool near-black, very low chroma to avoid "blue theme" */
+    --bg:         oklch(0.13 0.005 240);
+    --bg-2:       oklch(0.17 0.005 240);
+    --surface:    oklch(0.20 0.005 240);
+
+    /* Text
+     * --ink-mute is raised to oklch(0.55) so captions clear ~4:1 on --bg-2.
+     * Trade-off: less muted-looking, but readable. Note this in the PR.       */
+    --ink:        oklch(0.95 0.005 240);
+    --ink-soft:   oklch(0.72 0.008 240);
+    --ink-mute:   oklch(0.55 0.008 240);
+
+    /* Borders — subtle elevation steps on dark surfaces */
+    --rule:       oklch(0.32 0.005 240);   /* hard border */
+    --rule-soft:  oklch(0.25 0.005 240);   /* soft border / gridlines */
+
+    /* --accent: unchanged — brand blue works on dark */
+    /* --accent-12 auto-recomputes from --accent + --bg */
+
+    /* Highlight — slightly toned down so it's not glaring on dark */
+    --hilite-new: oklch(0.88 0.12 95);
+
+    /* Source badges — dark variants preserve hue identity
+     * while avoiding harsh light pastels on dark surfaces.
+     * Each pair uses the same hue angle as the light token.           */
+    --gh-bg: oklch(0.21 0.04 160);   --gh-fg: oklch(0.72 0.14 160);   /* Greenhouse — forest green */
+    --lv-bg: oklch(0.21 0.04 252);   --lv-fg: oklch(0.72 0.14 252);   /* Lever — navy blue        */
+    --wk-bg: oklch(0.21 0.06  45);   --wk-fg: oklch(0.72 0.14  45);   /* Workable — amber         */
+
+    /* Status */
+    --warning:     oklch(0.72 0.15 60);   /* unchanged — amber reads fine on dark */
+    --col-applied: oklch(0.70 0.14 75);   /* lighter amber for dark bg            */
+  }
 }
 
 /* ── Base ─────────────────────────────────────────────────────────────── */

--- a/frontend/app/saved/SavedPageClient.tsx
+++ b/frontend/app/saved/SavedPageClient.tsx
@@ -587,7 +587,7 @@ export default function SavedPageClient() {
                 fontSize: 12,
                 fontWeight: 500,
                 background: "var(--accent)",
-                color: "#ffffff",
+                color: "var(--on-accent)",
                 border: "none",
                 borderRadius: 6,
                 cursor: "not-allowed",

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -340,7 +340,7 @@ export default async function TrendsPage({
                     style={{
                       border: "1px solid var(--rule-soft)",
                       background: isActive ? "var(--accent)" : "transparent",
-                      color: isActive ? "white" : "var(--ink-mute)",
+                      color: isActive ? "var(--on-accent)" : "var(--ink-mute)",
                       fontFamily: "var(--font-mono)",
                       fontSize: 10,
                     }}

--- a/frontend/components/RadarCategorySelector.tsx
+++ b/frontend/components/RadarCategorySelector.tsx
@@ -152,7 +152,7 @@ export function RadarCategorySelector({ selectedCats: initialCats }: Props) {
                 background: isActive
                   ? `var(--cat-${cssSlug})`
                   : "var(--bg-2)",
-                color: isActive ? "#fff" : "var(--ink-soft)",
+                color: isActive ? "var(--on-accent)" : "var(--ink-soft)",
                 fontFamily: "var(--font-sans)",
                 fontSize: 11,
                 fontWeight: isActive ? 600 : 400,

--- a/frontend/components/SegmentFilter.tsx
+++ b/frontend/components/SegmentFilter.tsx
@@ -77,7 +77,7 @@ export function SegmentFilter({ activeSegment, selectedCats, activeWindow }: Pro
                   isActive ? "var(--accent)" : "var(--rule-soft)"
                 }`,
                 background: isActive ? "var(--accent)" : "transparent",
-                color: isActive ? "#fff" : "var(--ink-soft)",
+                color: isActive ? "var(--on-accent)" : "var(--ink-soft)",
                 fontFamily: "var(--font-sans)",
                 fontSize: 11,
                 fontWeight: isActive ? 600 : 400,


### PR DESCRIPTION
## Summary

Adds a `@media (prefers-color-scheme: dark)` block to `globals.css` that overrides all core design tokens for OS-level dark mode. No JS, no cookie, no toggle — pure CSS media query as specified in #52.

---

## What changed

### `frontend/app/globals.css` — main change

Added `--on-accent` token to `:root` (white text for colored/accent chip surfaces), then added the full dark-mode block:

| Token | Light | Dark |
|---|---|---|
| `--bg` | `oklch(0.97 0.012 85)` warm off-white | `oklch(0.13 0.005 240)` near-black |
| `--bg-2` | `oklch(0.94 0.014 85)` | `oklch(0.17 0.005 240)` |
| `--surface` | `#ffffff` | `oklch(0.20 0.005 240)` |
| `--ink` | `oklch(0.22 0.005 85)` | `oklch(0.95 0.005 240)` |
| `--ink-soft` | `oklch(0.42 0.008 85)` | `oklch(0.72 0.008 240)` |
| `--ink-mute` | `oklch(0.62 0.01 85)` | `oklch(0.55 0.008 240)`* |
| `--rule` | `oklch(0.27 0.005 85)` | `oklch(0.32 0.005 240)` |
| `--rule-soft` | `oklch(0.81 0.012 85)` | `oklch(0.25 0.005 240)` |
| `--accent` | `oklch(0.55 0.18 252)` | unchanged |
| `--accent-12` | color-mix from --accent+--bg | auto-recomputes in dark |
| `--hilite-new` | `oklch(0.92 0.13 95)` | `oklch(0.88 0.12 95)` |
| `--gh-bg/fg` | green pastel | `oklch(0.21 0.04 160)` / `oklch(0.72 0.14 160)` |
| `--lv-bg/fg` | blue pastel | `oklch(0.21 0.04 252)` / `oklch(0.72 0.14 252)` |
| `--wk-bg/fg` | orange pastel | `oklch(0.21 0.06 45)` / `oklch(0.72 0.14 45)` |
| `--col-applied` | `#b8860b` dark amber | `oklch(0.70 0.14 75)` lighter amber |

\* `--ink-mute` raised to L=0.55 (vs issue's L=0.50) for better contrast on `--bg-2` — see **Accessibility note** below.

### Component fixes (4 hardcoded colours replaced)

| File | Before | After |
|---|---|---|
| `components/RadarCategorySelector.tsx` | `"#fff"` on active category chip | `"var(--on-accent)"` |
| `components/SegmentFilter.tsx` | `"#fff"` on active segment pill | `"var(--on-accent)"` |
| `app/saved/SavedPageClient.tsx` | `"#ffffff"` on Add-alert button | `"var(--on-accent)"` |
| `app/trends/page.tsx` | `"white"` on active time-window pill | `"var(--on-accent)"` |

### Not changed (intentional)

- **`lib/radarHelpers.ts` / `/api/radar`** — server-side SVG export, always GitHub-dark palette, not a browser UI surface.
- **Category tokens (`--cat-*`)** — `oklch(0.55 0.18 …)` reads fine on dark backgrounds.
- **`RadarDownloadPanel`** — uses `var(--ink)` bg / `var(--bg)` text; naturally inverts to a light terminal card on a dark page, which is correct.

---

## Verification

```bash
cd frontend
npm run lint   # ✓ no new errors
npm run build  # ✓ compiled successfully, TypeScript passed
```

Manual check: toggle OS to dark mode in macOS System Settings → Appearance → Dark, then visit `/`, `/trends`, `/saved` at 375 / 768 / 1024 / 1440.

---

## Accessibility note

- **`--ink` on `--bg`**: est. contrast ~14:1 — exceeds AAA.
- **`--ink-soft` on `--surface`**: est. contrast ~6:1 — passes AA.
- **`--ink-mute` on `--bg-2`**: est. contrast ~3.8–4:1. Raised from issue's L=0.50 to L=0.55; still short of 4.5:1 but acceptable for secondary/caption text (WCAG AA large-text threshold is 3:1). Can be bumped further if measured contrast falls below 3:1.
- Source badge foreground/background pairs: each dark pair is oklch(L=0.72) on oklch(L=0.21), est. contrast ~9:1 — passes AA.
- Focus rings (`var(--accent)`) unchanged — remain visible in both modes.

---

Closes #52