### PR TITLE
fix: new_today — rolling 24h window instead of CURRENT_DATE

### DIFF
--- a/scripts/migrate_stats_rpc.sql
+++ b/scripts/migrate_stats_rpc.sql
@@ -5,10 +5,10 @@
 -- Safe to re-run: CREATE OR REPLACE + idempotent GRANT.
 --
 -- ⚠  DATE SEMANTICS
--- new_today uses CURRENT_DATE which is UTC midnight in Supabase.
--- The previous fetchStats() used JS `new Date(); setHours(0, 0, 0, 0)` on the
--- Next.js server (Vercel, UTC). Both resolve to UTC midnight — semantics match.
--- If you ever deploy the Next.js server in a non-UTC timezone, prefer AT TIME ZONE.
+-- new_today uses NOW() - INTERVAL '24 hours' (rolling window) to match the
+-- age() function in JobCard.tsx which also uses a rolling 24 h diff.
+-- Using CURRENT_DATE (UTC midnight) caused a mismatch: jobs from yesterday's
+-- noon UTC pipeline run (~22h old) showed "today" on cards but were not counted.
 --
 -- ⚠  REMOTE / HYBRID DEFINITION
 -- is_remote = true  → remote (counts toward remote_percent)
@@ -42,11 +42,14 @@ AS $$
 
     -- ── KPI strip ────────────────────────────────────────────────────────────
 
-    -- Jobs whose first_seen_at is on or after today's UTC midnight
+    -- Jobs first seen in the last 24 hours (rolling window, matches JobCard age()).
+    -- Using NOW() - INTERVAL '24 hours' instead of CURRENT_DATE to avoid the
+    -- mismatch where jobs from yesterday's noon UTC run (~22h old) show "today"
+    -- on cards but are not counted here.
     'new_today', (
       SELECT COUNT(*)
       FROM   active_qc_jobs
-      WHERE  first_seen_at >= CURRENT_DATE
+      WHERE  first_seen_at >= NOW() - INTERVAL '24 hours'
     ),
 
     -- Deduplicated company names


### PR DESCRIPTION
## Bug

The **new today** KPI counter showed 0 even when job cards displayed "today" labels.

## Root cause

Two different time windows were used for the same concept:

| Location | Logic | Window type |
|---|---|---|
| `JobCard.tsx` `age()` | `Math.floor(diffMs / 86_400_000)` | Rolling 24 h |
| `get_homepage_stats()` RPC | `WHERE first_seen_at >= CURRENT_DATE` | Calendar day (UTC midnight) |

**Concrete example:** Pipeline runs at 12:00 UTC (8 AM EDT). Before today's run fires, jobs from yesterday's run are ~22h old.
- `age()` → `floor(22/24) = 0` → card shows **"today"** ✅
- `CURRENT_DATE` → first_seen_at was on May 25, not May 26 → **not counted** ❌

## Fix

Change `new_today` to use a rolling 24 h window:

```sql
-- Before
WHERE first_seen_at >= CURRENT_DATE

-- After  
WHERE first_seen_at >= NOW() - INTERVAL '24 hours'
```

The KPI card sub-label already reads **"last 24 h"** — this makes the SQL match the label.

## ⚠️ Manual step required

Re-run `scripts/migrate_stats_rpc.sql` in Supabase SQL Editor (safe, uses `CREATE OR REPLACE`).

Closes #81 (if opened) — relates to the new_today = 0 bug report.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)