### PR TITLE
fix: preserve scroll position on trends filters

### DIFF
--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -336,6 +336,7 @@ export default async function TrendsPage({
                   <Link
                     key={w}
                     href={`/trends?${params.toString()}`}
+                    scroll={false}
                     className="rounded-full px-2 py-0.5 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--accent) focus-visible:ring-offset-1"
                     style={{
                       border: "1px solid var(--rule-soft)",

--- a/frontend/components/RadarCategorySelector.tsx
+++ b/frontend/components/RadarCategorySelector.tsx
@@ -57,7 +57,7 @@ export function RadarCategorySelector({ selectedCats: initialCats }: Props) {
       if (parsed.join(",") === initialCats.join(",")) return;
       const params = new URLSearchParams(searchParams.toString());
       params.set("cats", parsed.join(","));
-      router.replace(`/trends?${params.toString()}`);
+      router.replace(`/trends?${params.toString()}`, { scroll: false });
     } catch {
       // localStorage not available (SSR or private mode) — ignore
     }
@@ -82,7 +82,7 @@ export function RadarCategorySelector({ selectedCats: initialCats }: Props) {
 
     const params = new URLSearchParams(searchParams.toString());
     params.set("cats", newCats.join(","));
-    router.replace(`/trends?${params.toString()}`);
+    router.replace(`/trends?${params.toString()}`, { scroll: false });
 
     try {
       localStorage.setItem(STORAGE_KEY, newCats.join(","));

--- a/frontend/components/SegmentFilter.tsx
+++ b/frontend/components/SegmentFilter.tsx
@@ -66,6 +66,7 @@ export function SegmentFilter({ activeSegment, selectedCats, activeWindow }: Pro
             <Link
               key={slug ?? "all"}
               href={href(slug)}
+              scroll={false}
               aria-current={isActive ? "page" : undefined}
               style={{
                 display: "inline-flex",


### PR DESCRIPTION
## Summary

- `RadarCategorySelector`: added `{ scroll: false }` to both `router.replace()` calls (localStorage restore on mount + chip click handler) so clicking a sector chip no longer scrolls the page to top.
- `trends/page.tsx`: added `scroll={false}` to the time-window `<Link>` pills (7d / 30d / 90d / all) in the `WindowToggle` nav.
- `SegmentFilter.tsx`: added `scroll={false}` to every segment `<Link>` chip.

Cross-route navigation (e.g. bubble links to `/?tech=…`) is unaffected — those links do not carry `scroll={false}` and will still scroll to the top.

## Verification commands

```bash
cd frontend
npm run lint   # passes with no errors
npx tsc --noEmit   # passes with no type errors
```

## Manual scroll checks

1. Open `/trends` in a browser and scroll down until the radar chart and filter controls are mid-screen.
2. Click a radar sector chip → scroll position preserved. ✓
3. Switch between 7d / 30d / 90d / all pills → scroll position preserved. ✓
4. Switch a segment filter chip (e.g. Backend, Frontend) → scroll position preserved. ✓
5. Click a bubble link (`/?tech=React`) → cross-route navigation scrolls to top normally. ✓

Closes #80