### PR TITLE
feat: add Workday ATS source support

### DIFF
--- a/pipeline/extractor.py
+++ b/pipeline/extractor.py
@@ -20,9 +20,11 @@ logger = structlog.get_logger()
 
 SPECS_DIR = Path(__file__).parent.parent / "specs"
 
-# Maximum number of concurrent Workable detail-page requests.
-# Keeps the per-company fetch polite while still being meaningfully parallel.
+# Maximum number of concurrent detail-page requests (shared by Workable and Workday).
 _WORKABLE_DETAIL_CONCURRENCY = 5
+_WORKDAY_DETAIL_CONCURRENCY = 5
+# Safety cap on Workday pagination — no single company should exceed this.
+_WORKDAY_PAGINATION_CAP = 500
 
 
 # ─── Spec loading ────────────────────────────────────────────────────────────
@@ -93,6 +95,24 @@ def _parse_literal(s: str, field_type: str) -> Any:
     if field_type.startswith("list"):
         return []
     return s
+
+
+def _normalize_workday_date(date_str: str) -> str | None:
+    """Normalise a Workday startDate to an ISO 8601 UTC string.
+
+    Workday tenants emit dates in at least two formats:
+      - "MM/DD/YYYY" (e.g. "04/28/2026")
+      - ISO 8601 with or without timezone (e.g. "2026-04-28T00:00:00")
+    """
+    for fmt in ("%m/%d/%Y", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(date_str.strip(), fmt).replace(tzinfo=UTC).isoformat()
+        except (ValueError, TypeError):
+            pass
+    try:
+        return datetime.fromisoformat(date_str).astimezone(UTC).isoformat()
+    except (ValueError, TypeError):
+        return None
 
 
 # ─── Derived field helpers ───────────────────────────────────────────────────
@@ -208,6 +228,9 @@ class Extractor:
         return all_jobs
 
     async def _fetch_company(self, client: httpx.AsyncClient, company: dict) -> list[dict]:
+        if self.source == "workday":
+            return await self._fetch_workday_company(client, company)
+
         endpoint = self.schema["endpoint"]
         url = endpoint["url_template"].format(company_slug=company["slug"])
         log = logger.bind(source=self.source, company=company["name"])
@@ -303,6 +326,145 @@ class Extractor:
                 except httpx.HTTPError as exc:
                     logger.warning(
                         "workable_detail_fetch_failed",
+                        url=detail_url,
+                        error=str(exc),
+                    )
+
+        await asyncio.gather(*(_fetch_one(job) for job in raw_jobs))
+
+    # ─── Workday ─────────────────────────────────────────────────────────────
+
+    async def _fetch_workday_company(
+        self, client: httpx.AsyncClient, company: dict
+    ) -> list[dict]:
+        """Fetch all jobs for a single Workday tenant using the CXS JSON API.
+
+        Workday uses POST /jobs with offset-based pagination (20 jobs/page by default).
+        Each company defines its own ``api_url`` and ``base_url`` in schema.json because
+        Workday tenants have company-specific subdomains — there is no shared slug template.
+
+        After the list is fetched and company context is injected into each raw job,
+        detail pages are fetched concurrently to populate ``description_html`` and
+        ``_posted_at``. A failed detail fetch is logged and the job is retained with
+        ``description_html = null`` (title-only tech_stack extraction).
+        """
+        api_url = company.get("api_url", "")
+        if not api_url:
+            logger.warning("workday_missing_api_url", company=company["name"])
+            return []
+
+        log = logger.bind(source="workday", company=company["name"])
+        endpoint = self.schema["endpoint"]
+        request_body = dict(endpoint.get("request_body", {}))
+
+        raw_jobs: list[dict] = []
+        while True:
+            request_body["offset"] = len(raw_jobs)
+            try:
+                response = await client.post(api_url, json=request_body, timeout=30.0)
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                log.warning("fetch_http_error", status=exc.response.status_code, url=api_url)
+                break
+            except httpx.HTTPError as exc:
+                log.error("fetch_failed", error=str(exc), url=api_url)
+                break
+
+            data = response.json()
+            batch = data.get("jobPostings", [])
+            total = data.get("total", 0)
+            raw_jobs.extend(batch)
+
+            if not batch or len(raw_jobs) >= total:
+                break
+            if len(raw_jobs) >= _WORKDAY_PAGINATION_CAP:
+                log.warning("workday_pagination_capped", total=total, fetched=len(raw_jobs))
+                break
+
+        # Inject company URL context so the detail fetcher and extraction XML can use it.
+        # api_url ends with "/jobs"; strip that suffix to get the CXS api base.
+        api_base = api_url.removesuffix("/jobs")
+        base_url = company.get("base_url", "").rstrip("/")
+        for raw_job in raw_jobs:
+            ext_path = raw_job.get("externalPath", "")
+            raw_job["_api_base"] = api_base
+            raw_job["_base_url"] = base_url
+            raw_job["_external_id"] = raw_job.get("jobReqId") or (
+                ext_path.rstrip("/").rsplit("/", 1)[-1] if ext_path else None
+            )
+            if base_url and ext_path:
+                raw_job["_source_url"] = base_url + ext_path
+
+        await self._fetch_workday_descriptions(client, raw_jobs)
+
+        required = self.schema.get("validation", {}).get("required_fields", [])
+        results = []
+        for raw_job in raw_jobs:
+            if not all(raw_job.get(f) for f in required):
+                log.debug("job_skipped_missing_fields", job_id=raw_job.get("jobReqId"))
+                continue
+            extracted = self._apply_extraction(raw_job, company)
+            if is_non_tech_title(extracted.get("title", "")):
+                log.debug("job_skipped_non_tech_title", title=extracted.get("title"))
+                continue
+            results.append(extracted)
+
+        log.info("fetched", count=len(results))
+        return results
+
+    async def _fetch_workday_descriptions(
+        self, client: httpx.AsyncClient, raw_jobs: list[dict]
+    ) -> None:
+        """Fetch each Workday job's detail page and inject ``description_html``.
+
+        The CXS detail URL is derived by stripping the leading ``/{site}`` prefix from
+        ``externalPath`` and appending ``/details`` to the api base.  For example:
+
+            api_base    = https://example.wd3.myworkdayjobs.com/wday/cxs/example/ExampleCareers
+            externalPath = /ExampleCareers/job/Montreal/Engineer_JR-001
+            detail URL  = api_base + /job/Montreal/Engineer_JR-001 + /details
+
+        Requests are bounded to ``_WORKDAY_DETAIL_CONCURRENCY`` concurrent fetches.
+        A failed detail fetch is logged and the job continues without a description.
+        """
+        sem = asyncio.Semaphore(_WORKDAY_DETAIL_CONCURRENCY)
+
+        async def _fetch_one(raw_job: dict) -> None:
+            api_base: str = raw_job.pop("_api_base", "")
+            raw_job.pop("_base_url", None)
+            ext_path: str = raw_job.get("externalPath", "")
+
+            if not api_base or not ext_path:
+                return
+
+            site = api_base.rstrip("/").rsplit("/", 1)[-1]
+            job_suffix = re.sub(rf"^/{re.escape(site)}", "", ext_path, count=1)
+            detail_url = f"{api_base.rstrip('/')}{job_suffix}/details"
+
+            async with sem:
+                try:
+                    resp = await client.get(detail_url, timeout=30.0)
+                    resp.raise_for_status()
+                    info = resp.json().get("jobPostingInfo", {})
+                    description = info.get("jobDescription") or None
+                    raw_job["description_html"] = description
+                    start_date = info.get("startDate")
+                    if start_date:
+                        raw_job["_posted_at"] = _normalize_workday_date(start_date)
+                    logger.debug(
+                        "workday_detail_fetched",
+                        url=detail_url,
+                        bytes=len(resp.content),
+                    )
+                except httpx.HTTPStatusError as exc:
+                    logger.warning(
+                        "workday_detail_http_error",
+                        url=detail_url,
+                        status=exc.response.status_code,
+                    )
+                except httpx.HTTPError as exc:
+                    logger.warning(
+                        "workday_detail_fetch_failed",
                         url=detail_url,
                         error=str(exc),
                     )

--- a/specs/workday/extraction.xml
+++ b/specs/workday/extraction.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Workday extraction rules.
+
+  Source is the Workday CXS public JSON API (POST /jobs).
+  Each company defines its own api_url and base_url in schema.json because
+  Workday tenants have company-specific hostnames — there is no shared slug template.
+
+  Field injection (performed by _fetch_workday_company before this XML runs):
+    _external_id  — jobReqId, or last path segment of externalPath as fallback
+    _source_url   — base_url + externalPath (human-facing URL)
+    description_html — fetched from the CXS detail endpoint; null on failure
+    _posted_at    — startDate from detail endpoint, normalised to ISO UTC; null on failure
+
+  Tech extraction uses title + description_html, falling back to title-only when
+  the detail fetch fails.
+
+  Key differences vs other sources:
+  - List is fetched with POST (paginated 20/page); descriptions need a secondary GET
+  - externalPath drives both source_url construction and detail URL routing
+  - locationsText is the raw location string (e.g. "Montréal, Quebec, Canada")
+  - posted_at comes from the detail endpoint, not the list response
+-->
+<extraction source="workday" version="1">
+
+  <!-- ═══════════════════════════════════════════════════════
+       CONSTANTS — stamped uniformly on every record
+       ═══════════════════════════════════════════════════════ -->
+  <constants>
+    <constant name="source"           value="workday" />
+    <constant name="is_active"        value="true"    type="bool" />
+    <!-- Overridden by the description_html field below when the detail fetch
+         succeeds. Stays null on fetch failures so the job is still upserted
+         with title-only tech_stack. -->
+    <constant name="description_html" value="null"    />
+  </constants>
+
+  <!-- ═══════════════════════════════════════════════════════
+       FIELDS — direct mappings from the enriched raw job dict
+       ═══════════════════════════════════════════════════════ -->
+  <fields>
+    <!-- Pre-injected by _fetch_workday_company from jobReqId / externalPath -->
+    <field name="external_id"      from="_external_id"    type="string" />
+    <!-- Pre-injected by _fetch_workday_company as base_url + externalPath -->
+    <field name="source_url"       from="_source_url"     type="string"   nullable="true" />
+
+    <field name="title"            from="title"           type="string" />
+    <field name="location"         from="locationsText"   type="string"   nullable="true" />
+
+    <!-- Injected by detail fetch; stays null when fetch fails (constant above) -->
+    <field name="description_html" from="description_html" type="string"  nullable="true" />
+    <!-- Injected by detail fetch as a normalised ISO datetime string -->
+    <field name="posted_at"        from="_posted_at"      type="datetime" nullable="true" />
+  </fields>
+
+  <!-- ═══════════════════════════════════════════════════════
+       DERIVED — computed from already-mapped fields
+       ═══════════════════════════════════════════════════════ -->
+  <derived>
+
+    <!-- is_qc: true when location mentions a Quebec city or region -->
+    <field name="is_qc" type="bool" default="false">
+      <match source="location"
+             pattern="(?i)(montr[eé]al|qu[eé]bec|laval|longueuil|brossard|sherbrooke|gatineau|saint-jean|terrebonne|\bqc\b)"
+             value="true" />
+    </field>
+
+    <!-- is_remote: Workday locationsText may carry the workplace mode inline
+         e.g. "Remote", "Canada (Remote)", or a bare city with no qualifier. -->
+    <field name="is_remote" type="bool" default="null" nullable="true">
+      <match source="location" pattern="(?i)\bhybrid(e)?\b"                           value="null"  />
+      <match source="location" pattern="(?i)\bremote\b"                               value="true"  />
+      <match source="location" pattern="(?i)\b(on.?site|in.?office|pr[eé]sentiel)\b" value="false" />
+      <match source="title"    pattern="(?i)\bremote\b"                               value="true"  />
+    </field>
+
+    <field name="seniority" type="string" default="null" nullable="true">
+      <match source="title" pattern="(?i)\b(intern|stage|stagiaire|internship)\b"          value="internship" />
+      <match source="title" pattern="(?i)\b(junior|jr\.?|d[eé]butant)\b"                   value="junior"     />
+      <match source="title" pattern="(?i)\b(staff)\b"                                      value="staff"      />
+      <match source="title" pattern="(?i)\b(principal)\b"                                  value="principal"  />
+      <match source="title" pattern="(?i)\b(tech(nical)?\s+lead|lead\s+(dev|engineer))\b"  value="lead"       />
+      <match source="title" pattern="(?i)\b(senior|sr\.?|exp[eé]riment[eé])\b"             value="senior"     />
+      <match source="title" pattern="(?i)\b(director|directeur)\b"                         value="director"   />
+      <match source="title" pattern="(?i)\b(manager|gestionnaire|responsable)\b"           value="manager"    />
+    </field>
+
+    <!--
+      tech_stack: collect ALL keyword matches across title and description_html.
+      Falls back to title-only when description_html is null (failed detail fetch).
+    -->
+    <field name="tech_stack" type="list[string]" default="[]" strategy="collect-all">
+      <keywords sources="title,description_html" word_boundary="true" case_insensitive="true">
+
+        <!-- Languages -->
+        <kw canonical="Python">Python</kw>
+        <kw canonical="JavaScript">JavaScript</kw>
+        <kw canonical="TypeScript">TypeScript</kw>
+        <kw canonical="Go" case_sensitive="true">\b(?:Go|Golang)\b</kw>
+        <kw canonical="Rust">Rust</kw>
+        <kw canonical="Java">Java</kw>
+        <kw canonical="Kotlin">Kotlin</kw>
+        <kw canonical="Scala">Scala</kw>
+        <kw canonical="C#">C#</kw>
+        <kw canonical="C++">C\+\+</kw>
+        <kw canonical="Ruby">Ruby</kw>
+        <kw canonical="PHP">PHP</kw>
+        <kw canonical="Swift">Swift</kw>
+        <kw canonical="Elixir">Elixir</kw>
+        <kw canonical="Erlang">Erlang</kw>
+        <kw canonical="R" case_sensitive="true">\bR\b</kw>
+        <kw canonical="SQL" case_sensitive="true">\bSQL\b</kw>
+
+        <!-- Frontend / Web -->
+        <kw canonical="React">React</kw>
+        <kw canonical="Next.js">Next\.js</kw>
+        <kw canonical="Vue">Vue(?:\.js)?</kw>
+        <kw canonical="Angular">Angular</kw>
+        <kw canonical="Svelte">Svelte</kw>
+        <kw canonical="Node.js">Node(?:\.js)?</kw>
+        <kw canonical="Express">Express</kw>
+        <kw canonical="GraphQL">GraphQL</kw>
+        <kw canonical="REST" case_sensitive="true">REST(?:ful)?</kw>
+        <kw canonical="Tailwind">Tailwind(?:\s+CSS)?</kw>
+        <kw canonical="Redux">Redux</kw>
+
+        <!-- Backend frameworks -->
+        <kw canonical="Django">Django</kw>
+        <kw canonical="FastAPI">FastAPI</kw>
+        <kw canonical="Flask">Flask</kw>
+        <kw canonical="Rails">(?:Ruby on )?Rails</kw>
+        <kw canonical="Spring Boot">Spring(?:\s+Boot)?</kw>
+        <kw canonical="NestJS">NestJS</kw>
+        <kw canonical="gRPC">gRPC</kw>
+        <kw canonical="Laravel">Laravel</kw>
+        <kw canonical="ASP.NET">ASP\.NET</kw>
+        <kw canonical=".NET">\.NET</kw>
+
+        <!-- Data / ML / AI -->
+        <kw canonical="Spark">(?:Apache )?Spark</kw>
+        <kw canonical="Kafka">(?:Apache )?Kafka</kw>
+        <kw canonical="Airflow">(?:Apache )?Airflow</kw>
+        <kw canonical="dbt">dbt</kw>
+        <kw canonical="Pandas">Pandas</kw>
+        <kw canonical="NumPy">NumPy</kw>
+        <kw canonical="PyTorch">PyTorch</kw>
+        <kw canonical="TensorFlow">TensorFlow</kw>
+        <kw canonical="scikit-learn">scikit-learn</kw>
+        <kw canonical="LLM" case_sensitive="true">LLM</kw>
+        <kw canonical="RAG" case_sensitive="true">RAG</kw>
+        <kw canonical="Flink">(?:Apache )?Flink</kw>
+        <kw canonical="LangChain">LangChain</kw>
+        <kw canonical="OpenAI" case_sensitive="true">OpenAI</kw>
+        <kw canonical="MLflow">MLflow</kw>
+        <kw canonical="Vector DB">(?:Pinecone|Qdrant|Weaviate|Chroma|vector\s+(?:database|store|DB))</kw>
+
+        <!-- Infrastructure / Cloud -->
+        <kw canonical="AWS">AWS</kw>
+        <kw canonical="GCP">GCP</kw>
+        <kw canonical="Azure">Azure</kw>
+        <kw canonical="Kubernetes">Kubernetes</kw>
+        <kw canonical="Docker">Docker</kw>
+        <kw canonical="Terraform">Terraform</kw>
+        <kw canonical="Ansible">Ansible</kw>
+        <kw canonical="CI/CD">CI/CD</kw>
+        <kw canonical="GitHub Actions">GitHub Actions</kw>
+        <kw canonical="Jenkins">Jenkins</kw>
+        <kw canonical="Helm">Helm</kw>
+        <kw canonical="ArgoCD">Argo\s*CD</kw>
+        <kw canonical="Prometheus">Prometheus</kw>
+        <kw canonical="Grafana">Grafana</kw>
+        <kw canonical="Nginx">Nginx</kw>
+        <kw canonical="Cloudflare">Cloudflare</kw>
+
+        <!-- Databases -->
+        <kw canonical="PostgreSQL">Postgres(?:QL)?</kw>
+        <kw canonical="MySQL">MySQL</kw>
+        <kw canonical="MongoDB">MongoDB</kw>
+        <kw canonical="Redis">Redis</kw>
+        <kw canonical="Elasticsearch">Elasticsearch</kw>
+        <kw canonical="Snowflake">Snowflake</kw>
+        <kw canonical="BigQuery">BigQuery</kw>
+        <kw canonical="DynamoDB">DynamoDB</kw>
+        <kw canonical="Cassandra">Cassandra</kw>
+
+        <!-- Mobile -->
+        <kw canonical="Android">Android</kw>
+        <kw canonical="iOS">iOS</kw>
+        <kw canonical="React Native">React Native</kw>
+        <kw canonical="Flutter">Flutter</kw>
+        <kw canonical="SwiftUI">SwiftUI</kw>
+
+        <!-- Testing / QA -->
+        <kw canonical="Jest">Jest</kw>
+        <kw canonical="Cypress">Cypress</kw>
+        <kw canonical="Playwright">Playwright</kw>
+        <kw canonical="Selenium">Selenium</kw>
+        <kw canonical="JUnit">JUnit</kw>
+        <kw canonical="Postman">Postman</kw>
+
+      </keywords>
+    </field>
+
+  </derived>
+
+</extraction>

--- a/specs/workday/schema.json
+++ b/specs/workday/schema.json
@@ -1,0 +1,26 @@
+{
+  "source": "workday",
+  "display_name": "Workday",
+  "endpoint": {
+    "method": "POST",
+    "url_template": null,
+    "request_body": {
+      "appliedFacets": {},
+      "limit": 20,
+      "offset": 0,
+      "searchText": ""
+    },
+    "response_format": "json",
+    "jobs_path": "jobPostings",
+    "rate_limit": {
+      "requests_per_second": 2,
+      "delay_between_companies_ms": 500
+    }
+  },
+  "companies": [],
+  "validation": {
+    "required_fields": ["title", "_external_id"],
+    "min_jobs_per_company": 0,
+    "warn_if_empty": true
+  }
+}

--- a/specs/workday/source.md
+++ b/specs/workday/source.md
@@ -1,0 +1,201 @@
+# Workday — Source Documentation
+
+## What is Workday?
+
+Workday is an enterprise HR/ATS platform used by banks, insurance companies, telcos,
+universities, and large tech employers. Unlike Greenhouse and Lever, Workday has no
+shared public API hostname — each company operates its own tenant on a company-specific
+subdomain (`{tenant}.wd{N}.myworkdayjobs.com`).
+
+## API overview
+
+Workday exposes a public, unauthenticated **CXS JSON API** on every tenant for reading
+job listings. This is the same API that powers the Workday public career portal.
+
+### List endpoint
+
+**URL:** `https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs`  
+**Method:** POST  
+**Auth:** None (public endpoint)  
+**Content-Type:** `application/json`
+
+```json
+{
+  "appliedFacets": {},
+  "limit": 20,
+  "offset": 0,
+  "searchText": ""
+}
+```
+
+The response includes `total` (total matching jobs) and `jobPostings` (current page).
+The extractor paginates automatically until all jobs are fetched, capped at 500.
+
+### Detail endpoint
+
+**URL:** `https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/job/{job-path}/details`  
+**Method:** GET  
+**Auth:** None
+
+The `{job-path}` portion is derived by stripping the leading `/{site}` prefix from
+the list response's `externalPath` field. For example:
+
+```
+externalPath = "/BellCareers/job/Montreal/Cloud-Engineer_JR-2000"
+site         = "BellCareers"   (last segment of api_url)
+job-path     = "/job/Montreal/Cloud-Engineer_JR-2000"
+detail URL   = https://bell.wd3.myworkdayjobs.com/wday/cxs/bell/BellCareers
+               /job/Montreal/Cloud-Engineer_JR-2000/details
+```
+
+The detail response contains:
+- `jobPostingInfo.jobDescription` — full HTML job description (maps to `description_html`)
+- `jobPostingInfo.startDate` — posting date (maps to `posted_at`, normalised to ISO UTC)
+
+---
+
+## Schema entry per company
+
+Because each Workday tenant has a unique hostname, each company in `schema.json` requires
+two URL fields instead of a simple slug:
+
+```json
+{
+  "name": "Example Corp",
+  "slug": "example-corp",
+  "api_url": "https://example.wd3.myworkdayjobs.com/wday/cxs/example/ExampleCareers/jobs",
+  "base_url": "https://example.wd3.myworkdayjobs.com"
+}
+```
+
+| Field      | Purpose                                                         |
+|------------|-----------------------------------------------------------------|
+| `name`     | Display name — stored in canonical `company` field             |
+| `slug`     | Machine-readable identifier for dedup and logging              |
+| `api_url`  | Full CXS `/jobs` endpoint URL (POST target)                    |
+| `base_url` | Tenant domain root — used to construct human-facing source_url |
+
+The human-facing `source_url` is: `base_url + externalPath`  
+(e.g., `https://example.wd3.myworkdayjobs.com/ExampleCareers/job/Montreal/Engineer_JR-001`)
+
+---
+
+## Tenant/URL discovery
+
+To find a company's Workday tenant:
+
+1. **From the careers page URL:** If the company links to
+   `https://company.wd3.myworkdayjobs.com/...`, the tenant is `company` and `N=3`.
+2. **From LinkedIn/job boards:** Job postings often link to the Workday tenant directly.
+3. **Verification:**
+   ```bash
+   curl -s -X POST \
+     "https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs" \
+     -H "Content-Type: application/json" \
+     -d '{"appliedFacets":{},"limit":1,"offset":0,"searchText":""}' | jq '.total'
+   ```
+   A numeric `total` confirms the endpoint is live.
+
+### Workday version (wd1 through wd5)
+
+Workday assigns tenants to different infrastructure versions (`wd1`, `wd2`, `wd3`, `wd5`).
+The version is embedded in the tenant hostname. Always use the correct version from the
+company's actual careers page URL — the CXS API path is identical across versions.
+
+---
+
+## List response structure
+
+```json
+{
+  "total": 45,
+  "jobPostings": [
+    {
+      "title": "Cloud Engineer",
+      "externalPath": "/BellCareers/job/Montreal-Quebec/Cloud-Engineer_JR-2000",
+      "locationsText": "Montréal, Quebec, Canada",
+      "postedOn": "Posted 3 Days Ago",
+      "jobReqId": "JR-2000",
+      "bulletFields": ["Full time", "JR-2000"]
+    }
+  ]
+}
+```
+
+### Field notes
+
+| Field          | Canonical mapping     | Notes                                                       |
+|----------------|-----------------------|-------------------------------------------------------------|
+| `title`        | `title`               | Raw job title                                               |
+| `externalPath` | derives `external_id`, `source_url`, detail URL | Always present; company-unique |
+| `locationsText`| `location`            | Free-text, e.g. `"Montréal, Quebec, Canada"`               |
+| `postedOn`     | ignored               | Relative string ("Posted 3 Days Ago") — use detail `startDate` instead |
+| `jobReqId`     | `external_id` (preferred) | e.g. `JR-2000`; falls back to last path segment if absent |
+| `bulletFields` | ignored               | Truncated bullets; full description comes from detail fetch |
+
+---
+
+## Field injection (pre-extraction enrichment)
+
+Before the extraction XML runs, `_fetch_workday_company` injects:
+
+| Injected key      | Source                                      |
+|-------------------|---------------------------------------------|
+| `_external_id`    | `jobReqId` if present, else last path segment of `externalPath` |
+| `_source_url`     | `base_url + externalPath`                   |
+| `description_html`| `jobPostingInfo.jobDescription` from detail endpoint |
+| `_posted_at`      | `jobPostingInfo.startDate` (normalised to ISO UTC) |
+
+---
+
+## Pagination
+
+The CXS API returns 20 jobs per page by default. The extractor fetches successive pages
+(incrementing `offset`) until `len(fetched) >= total`. A safety cap of 500 jobs per
+company prevents runaway loops. Companies with >500 open jobs are logged with a warning.
+
+---
+
+## Detail-fetch strategy
+
+All detail pages for a company's jobs are fetched concurrently, bounded to 5 simultaneous
+requests (same semaphore as Workable). A failed detail fetch is logged and the job is still
+upserted with `description_html = null`; `tech_stack` falls back to title-only.
+
+---
+
+## Known quirks and unsupported variants
+
+1. **`startDate` format varies by tenant** — some return `"MM/DD/YYYY"`, others return
+   ISO 8601. The normaliser tries both formats before giving up.
+2. **`jobReqId` may be absent** — some tenants omit this field. The fallback extracts
+   the last path segment of `externalPath` as `external_id`.
+3. **`locationsText` can list multiple cities** — e.g. `"Montréal or Toronto, Canada"`.
+   The `is_qc` derivation still fires if any Quebec city appears in the string.
+4. **No built-in location filter** — unlike Workable (which has `location[0][country]`),
+   the Workday CXS API does not reliably support location-based facets across all tenants.
+   We fetch all jobs and rely on the `is_qc` derivation rule to filter.
+5. **`appliedFacets` location filtering** — some tenants support location facets via
+   `appliedFacets`, but the facet keys are tenant-specific and not discoverable without
+   a prior facets request. Not implemented in this version.
+6. **JavaScript-rendered career portals** — some Workday tenants are configured with a
+   custom front-end and do not expose the standard CXS endpoint. These are incompatible
+   with this adapter and must be skipped; symptoms: 404 or HTML response from POST /jobs.
+
+---
+
+## Deduplication strategy
+
+```
+UNIQUE KEY: (source='workday', external_id, company_slug)
+```
+
+`external_id` is `jobReqId` when present, else the last path segment of `externalPath`.
+Both are stable across fetches for the same job posting.
+
+---
+
+## Company rollout
+
+The Quebec Workday company list is managed in issue #75. This file documents the adapter
+mechanics. See #75 for the validated list of tenant URLs.

--- a/tests/fixtures/workday_fixture_swe_raw.json
+++ b/tests/fixtures/workday_fixture_swe_raw.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "Simulated raw Workday job dict as produced by _fetch_workday_company AFTER context injection and detail-page enrichment. Technologies (Python, FastAPI, PostgreSQL, Docker, AWS, Kubernetes, GitHub Actions) appear only in description_html, NOT in the title — mirrors the regression pattern from issue #56 for Workday.",
+  "title": "Software Engineer, Backend",
+  "externalPath": "/FixtureCareers/job/Montreal-Quebec/Software-Engineer-Backend_JR-00001",
+  "locationsText": "Montréal, Quebec, Canada",
+  "postedOn": "Posted 5 Days Ago",
+  "jobReqId": "JR-00001",
+  "bulletFields": ["Full time", "JR-00001"],
+  "_external_id": "JR-00001",
+  "_source_url": "https://fixturecorp.wd3.myworkdayjobs.com/FixtureCareers/job/Montreal-Quebec/Software-Engineer-Backend_JR-00001",
+  "description_html": "<div><h1>About the Role</h1><p>We are looking for a Backend Engineer to join our platform team. The ideal candidate has experience with Python and FastAPI to build high-performance REST APIs. You will work with PostgreSQL as our primary database, use Docker for containerization, and deploy to AWS using Kubernetes. Our team runs CI/CD pipelines through GitHub Actions.</p><h2>Requirements</h2><ul><li>3+ years of Python experience</li><li>Proficiency with FastAPI or similar async frameworks</li><li>Experience with PostgreSQL and query optimization</li><li>Docker and Kubernetes knowledge</li><li>Familiarity with AWS services (EKS, RDS, S3)</li></ul></div>",
+  "_posted_at": "2026-04-28T00:00:00+00:00"
+}

--- a/tests/test_workday_extraction.py
+++ b/tests/test_workday_extraction.py
@@ -1,0 +1,399 @@
+"""Tests for Workday Layer-1 extraction (issue #74).
+
+Covers:
+  1. Core field mapping — all canonical fields are populated correctly.
+  2. Tech stack extraction from description_html (same regression pattern as issue #56).
+  3. is_qc derivation from Workday's locationsText format.
+  4. Title-only fallback when description_html is absent (failed detail fetch).
+  5. Word-boundary safety in description content.
+  6. Async detail-fetch: injection, HTTP errors, network errors.
+  7. Existing sources (Greenhouse, Lever, Workable) are unaffected — schema still loads.
+
+Fixture: tests/fixtures/workday_fixture_swe_raw.json
+  A fictional "Fixture Corp" Software Engineer posting whose technologies
+  (Python, FastAPI, PostgreSQL, Docker, AWS, Kubernetes, GitHub Actions) appear
+  only in the description — not in the title.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pipeline.extractor import Extractor, _normalize_workday_date
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+_COMPANY = {
+    "name": "Fixture Corp",
+    "slug": "fixture-corp",
+    "api_url": "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers/jobs",
+    "base_url": "https://fixturecorp.wd3.myworkdayjobs.com",
+}
+
+
+@pytest.fixture(scope="module")
+def workday() -> Extractor:
+    return Extractor("workday")
+
+
+@pytest.fixture(scope="module")
+def swe_raw() -> dict:
+    return json.loads((FIXTURES / "workday_fixture_swe_raw.json").read_text())
+
+
+# ─── Core field mapping ───────────────────────────────────────────────────────
+
+
+class TestWorkdayFieldMapping:
+    """All canonical fields must be correctly populated from the enriched raw dict."""
+
+    def test_source_constant(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["source"] == "workday"
+
+    def test_is_active_constant(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["is_active"] is True
+
+    def test_company_from_schema(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["company"] == "Fixture Corp"
+        assert result["company_slug"] == "fixture-corp"
+
+    def test_title(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["title"] == "Software Engineer, Backend"
+
+    def test_external_id(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["external_id"] == "JR-00001"
+
+    def test_source_url(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert "fixturecorp.wd3.myworkdayjobs.com" in result["source_url"]
+        assert "JR-00001" in result["source_url"]
+
+    def test_location(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["location"] == "Montréal, Quebec, Canada"
+
+    def test_posted_at(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["posted_at"] is not None
+        assert "2026-04-28" in result["posted_at"]
+
+    def test_description_html_populated(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["description_html"] is not None
+        assert "Python" in result["description_html"]
+
+    def test_no_enriched_tech_stack(self, workday: Extractor, swe_raw: dict) -> None:
+        """Layer 1 must never write enriched_tech_stack."""
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert "enriched_tech_stack" not in result
+
+
+# ─── Tech extraction from description ────────────────────────────────────────
+
+
+class TestWorkdayTechExtraction:
+    """Technologies in description_html must be extracted into tech_stack."""
+
+    def test_techs_in_description_extracted(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        stack = set(result["tech_stack"])
+        # All of these appear in description_html, not in the title
+        expected = {"Python", "FastAPI", "PostgreSQL", "Docker", "AWS", "Kubernetes", "GitHub Actions"}
+        missing = expected - stack
+        assert not missing, (
+            f"Technologies from description_html are missing from tech_stack: {missing}. "
+            "The detail-page content must flow into keyword extraction."
+        )
+
+    def test_tech_stack_is_list(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert isinstance(result["tech_stack"], list)
+        assert len(result["tech_stack"]) > 0
+
+
+# ─── QC and remote derivation ─────────────────────────────────────────────────
+
+
+class TestWorkdayDerivedFields:
+    def test_is_qc_montreal(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["is_qc"] is True
+
+    def test_not_qc_toronto(self, workday: Extractor) -> None:
+        raw = {**_base_raw(), "locationsText": "Toronto, Ontario, Canada"}
+        result = workday._apply_extraction(raw, _COMPANY)
+        assert result["is_qc"] is False
+
+    def test_is_remote_none_for_onsite(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        # No remote/hybrid keyword in locationsText → null
+        assert result["is_remote"] is None
+
+    def test_is_remote_true(self, workday: Extractor) -> None:
+        raw = {**_base_raw(), "locationsText": "Remote"}
+        result = workday._apply_extraction(raw, _COMPANY)
+        assert result["is_remote"] is True
+
+    def test_is_remote_null_for_hybrid(self, workday: Extractor) -> None:
+        raw = {**_base_raw(), "locationsText": "Montréal, Quebec, Canada (Hybrid)"}
+        result = workday._apply_extraction(raw, _COMPANY)
+        assert result["is_remote"] is None
+
+    def test_seniority_senior(self, workday: Extractor) -> None:
+        raw = {**_base_raw(), "title": "Senior Python Developer"}
+        result = workday._apply_extraction(raw, _COMPANY)
+        assert result["seniority"] == "senior"
+
+    def test_seniority_null_for_untagged(self, workday: Extractor, swe_raw: dict) -> None:
+        result = workday._apply_extraction(swe_raw, _COMPANY)
+        assert result["seniority"] is None
+
+
+# ─── Fallback: no description_html ───────────────────────────────────────────
+
+
+class TestWorkdayDescriptionFallback:
+    """When description_html is absent (failed detail fetch) the job must survive."""
+
+    def test_title_only_fallback(self, workday: Extractor) -> None:
+        raw = {
+            "title": "Senior Python Developer",
+            "externalPath": "/FixtureCareers/job/Montreal/Senior-Python-Developer_JR-99999",
+            "locationsText": "Montréal, Quebec, Canada",
+            "jobReqId": "JR-99999",
+            "_external_id": "JR-99999",
+            "_source_url": "https://fixturecorp.wd3.myworkdayjobs.com/FixtureCareers/job/Montreal/Senior-Python-Developer_JR-99999",
+            # description_html intentionally absent
+        }
+        result = workday._apply_extraction(raw, _COMPANY)
+        assert result["description_html"] is None, "Fallback constant must be null"
+        assert "Python" in result["tech_stack"], "Python from title must still be extracted"
+
+    def test_explicit_null_description_no_crash(self, workday: Extractor) -> None:
+        raw = {**_base_raw(), "description_html": None}
+        result = workday._apply_extraction(raw, _COMPANY)
+        assert isinstance(result["tech_stack"], list)
+
+
+# ─── Word-boundary safety ─────────────────────────────────────────────────────
+
+
+class TestWorkdayWordBoundaries:
+    def test_rust_not_matched_in_trust(self, workday: Extractor) -> None:
+        raw = {**_base_raw(), "description_html": "We trust our teams to deliver quality."}
+        result = workday._apply_extraction(raw, _COMPANY)
+        assert "Rust" not in result["tech_stack"]
+
+    def test_java_not_matched_in_javascript(self, workday: Extractor) -> None:
+        raw = {**_base_raw(), "description_html": "You will use JavaScript and TypeScript."}
+        result = workday._apply_extraction(raw, _COMPANY)
+        assert "Java" not in result["tech_stack"]
+        assert "JavaScript" in result["tech_stack"]
+        assert "TypeScript" in result["tech_stack"]
+
+
+# ─── Date normalization ───────────────────────────────────────────────────────
+
+
+class TestNormalizeWorkdayDate:
+    def test_mm_dd_yyyy(self) -> None:
+        result = _normalize_workday_date("04/28/2026")
+        assert result is not None
+        assert "2026-04-28" in result
+
+    def test_iso_no_tz(self) -> None:
+        result = _normalize_workday_date("2026-04-28T00:00:00")
+        assert result is not None
+        assert "2026-04-28" in result
+
+    def test_iso_with_offset(self) -> None:
+        result = _normalize_workday_date("2026-04-28T12:00:00-04:00")
+        assert result is not None
+        assert "2026-04-28" in result
+
+    def test_invalid_returns_none(self) -> None:
+        assert _normalize_workday_date("not-a-date") is None
+
+    def test_empty_returns_none(self) -> None:
+        assert _normalize_workday_date("") is None
+
+
+# ─── Async: _fetch_workday_descriptions ──────────────────────────────────────
+
+
+class TestFetchWorkdayDescriptions:
+    """Unit tests for the async detail-fetch method (no real HTTP calls)."""
+
+    @pytest.mark.asyncio
+    async def test_description_and_date_injected(self, workday: Extractor) -> None:
+        raw_job: dict = {
+            "externalPath": "/FixtureCareers/job/Montreal/Engineer_JR-001",
+            "_api_base": "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers",
+            "_base_url": "https://fixturecorp.wd3.myworkdayjobs.com",
+        }
+        detail_response = {
+            "jobPostingInfo": {
+                "jobDescription": "<p>We use Python and Docker.</p>",
+                "startDate": "2026-04-28T00:00:00",
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = detail_response
+        mock_resp.content = b"..."
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        await workday._fetch_workday_descriptions(mock_client, [raw_job])
+
+        assert raw_job["description_html"] == "<p>We use Python and Docker.</p>"
+        assert raw_job.get("_posted_at") is not None
+        assert "2026-04-28" in raw_job["_posted_at"]
+        # Context keys must be cleaned up
+        assert "_api_base" not in raw_job
+        assert "_base_url" not in raw_job
+
+    @pytest.mark.asyncio
+    async def test_detail_url_construction(self, workday: Extractor) -> None:
+        """Detail URL strips site prefix from externalPath and appends /details."""
+        raw_job: dict = {
+            "externalPath": "/FixtureCareers/job/Montreal/Engineer_JR-001",
+            "_api_base": "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers",
+            "_base_url": "https://fixturecorp.wd3.myworkdayjobs.com",
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"jobPostingInfo": {"jobDescription": "desc"}}
+        mock_resp.content = b"desc"
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        await workday._fetch_workday_descriptions(mock_client, [raw_job])
+
+        expected_url = (
+            "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers"
+            "/job/Montreal/Engineer_JR-001/details"
+        )
+        mock_client.get.assert_awaited_once_with(expected_url, timeout=30.0)
+
+    @pytest.mark.asyncio
+    async def test_http_error_does_not_raise(self, workday: Extractor) -> None:
+        import httpx
+
+        raw_job: dict = {
+            "externalPath": "/FixtureCareers/job/Montreal/Engineer_JR-002",
+            "_api_base": "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers",
+            "_base_url": "https://fixturecorp.wd3.myworkdayjobs.com",
+        }
+        mock_request = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(
+            side_effect=httpx.HTTPStatusError("404", request=mock_request, response=mock_response)
+        )
+
+        await workday._fetch_workday_descriptions(mock_client, [raw_job])
+
+        assert "description_html" not in raw_job
+        assert "_posted_at" not in raw_job
+
+    @pytest.mark.asyncio
+    async def test_network_error_does_not_raise(self, workday: Extractor) -> None:
+        import httpx
+
+        raw_job: dict = {
+            "externalPath": "/FixtureCareers/job/Montreal/Engineer_JR-003",
+            "_api_base": "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers",
+            "_base_url": "https://fixturecorp.wd3.myworkdayjobs.com",
+        }
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("timeout"))
+
+        await workday._fetch_workday_descriptions(mock_client, [raw_job])
+
+        assert "description_html" not in raw_job
+
+    @pytest.mark.asyncio
+    async def test_missing_external_path_skipped(self, workday: Extractor) -> None:
+        raw_job: dict = {
+            "title": "Engineer",
+            "externalPath": "",
+            "_api_base": "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers",
+            "_base_url": "https://fixturecorp.wd3.myworkdayjobs.com",
+        }
+        mock_client = AsyncMock()
+
+        await workday._fetch_workday_descriptions(mock_client, [raw_job])
+
+        mock_client.get.assert_not_awaited()
+        assert "description_html" not in raw_job
+
+    @pytest.mark.asyncio
+    async def test_null_jobdescription_stored_as_none(self, workday: Extractor) -> None:
+        """jobDescription: null in the detail response must be stored as Python None."""
+        raw_job: dict = {
+            "externalPath": "/FixtureCareers/job/Montreal/Engineer_JR-004",
+            "_api_base": "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers",
+            "_base_url": "https://fixturecorp.wd3.myworkdayjobs.com",
+        }
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"jobPostingInfo": {"jobDescription": None}}
+        mock_resp.content = b""
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+
+        await workday._fetch_workday_descriptions(mock_client, [raw_job])
+
+        assert raw_job.get("description_html") is None
+
+
+# ─── Existing sources unaffected ─────────────────────────────────────────────
+
+
+class TestExistingSourcesUnaffected:
+    """Ensure Workday changes don't break Greenhouse, Lever, or Workable schemas."""
+
+    def test_greenhouse_schema_loads(self) -> None:
+        ex = Extractor("greenhouse")
+        assert ex.source == "greenhouse"
+        assert ex.schema["source"] == "greenhouse"
+
+    def test_lever_schema_loads(self) -> None:
+        ex = Extractor("lever")
+        assert ex.source == "lever"
+        assert ex.schema["source"] == "lever"
+
+    def test_workable_schema_loads(self) -> None:
+        ex = Extractor("workable")
+        assert ex.source == "workable"
+        assert ex.schema["source"] == "workable"
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _base_raw() -> dict:
+    """Minimal valid raw Workday job dict with injected context fields."""
+    return {
+        "title": "Software Engineer",
+        "externalPath": "/FixtureCareers/job/Montreal/Software-Engineer_JR-00001",
+        "locationsText": "Montréal, Quebec, Canada",
+        "jobReqId": "JR-00001",
+        "_external_id": "JR-00001",
+        "_source_url": "https://fixturecorp.wd3.myworkdayjobs.com/FixtureCareers/job/Montreal/Software-Engineer_JR-00001",
+    }

--- a/tests/test_workday_extraction.py
+++ b/tests/test_workday_extraction.py
@@ -107,7 +107,10 @@ class TestWorkdayTechExtraction:
         result = workday._apply_extraction(swe_raw, _COMPANY)
         stack = set(result["tech_stack"])
         # All of these appear in description_html, not in the title
-        expected = {"Python", "FastAPI", "PostgreSQL", "Docker", "AWS", "Kubernetes", "GitHub Actions"}
+        expected = {
+            "Python", "FastAPI", "PostgreSQL", "Docker",
+            "AWS", "Kubernetes", "GitHub Actions",
+        }
         missing = expected - stack
         assert not missing, (
             f"Technologies from description_html are missing from tech_stack: {missing}. "


### PR DESCRIPTION
## Summary

- Adds Workday as a fourth supported ATS source in the pipeline, unlocking enterprise, bank, insurance, telco, and university employers (Quebec rollout in #75)
- Implements the public Workday CXS JSON API: POST `/jobs` with offset pagination + secondary GET `/job/{path}/details` for full descriptions
- Each Workday tenant has a company-specific subdomain; `schema.json` companies carry `api_url` + `base_url` instead of a shared slug template
- 37 new tests — all 277 pass; existing Greenhouse, Lever, and Workable behaviour is unchanged

## Workday URL/API strategy

**List endpoint (POST):**
```
POST https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/jobs
Content-Type: application/json
{"appliedFacets": {}, "limit": 20, "offset": 0, "searchText": ""}
```

**Detail endpoint (GET):**
```
GET {api_base}/job/{externalPath-stripped-of-site-prefix}/details
```
Returns `jobPostingInfo.jobDescription` (HTML) and `jobPostingInfo.startDate`.

**Tenant discovery:** `api_url` and `base_url` are stored per-company in `schema.json`. `source.md` documents the curl verification command.

## Verification commands

```bash
# All tests (277 pass)
.venv/bin/pytest

# Workday-only tests (37 pass)
.venv/bin/pytest tests/test_workday_extraction.py -v

# Extractor smoke test (empty companies list — safe to run without credentials)
python -m pipeline.extractor workday
```

## Files changed

| File | Change |
|------|--------|
| `pipeline/extractor.py` | +`_fetch_workday_company`, `_fetch_workday_descriptions`, `_normalize_workday_date`; `_fetch_company` dispatches to Workday path |
| `specs/workday/schema.json` | POST endpoint config; empty companies array (rollout in #75) |
| `specs/workday/extraction.xml` | Field mappings aligned with other sources |
| `specs/workday/source.md` | API strategy, URL discovery, tenant config, known quirks |
| `tests/fixtures/workday_fixture_swe_raw.json` | Realistic enriched raw job for offline tests |
| `tests/test_workday_extraction.py` | 37 tests across field mapping, tech extraction, error handling |

## Known unsupported Workday variants

1. **Custom-frontend tenants** — some companies configure a non-standard front-end; the CXS POST `/jobs` endpoint returns 404 or HTML. These must be skipped (logged as `fetch_http_error`).
2. **Location facet filtering** — Workday facet keys are tenant-specific; no location pre-filter is applied. All jobs are fetched and `is_qc` derivation filters to Quebec.
3. **>500 open jobs** — pagination is capped at 500 per company; an overflow warning is logged.

Closes #74