### PR TITLE
feat: add Quebec Workday company specs

### DIFF
--- a/pipeline/extractor.py
+++ b/pipeline/extractor.py
@@ -439,7 +439,7 @@ class Extractor:
 
             site = api_base.rstrip("/").rsplit("/", 1)[-1]
             job_suffix = re.sub(rf"^/{re.escape(site)}", "", ext_path, count=1)
-            detail_url = f"{api_base.rstrip('/')}{job_suffix}/details"
+            detail_url = f"{api_base.rstrip('/')}{job_suffix}"
 
             async with sem:
                 try:

--- a/specs/workday/schema.json
+++ b/specs/workday/schema.json
@@ -17,7 +17,56 @@
       "delay_between_companies_ms": 500
     }
   },
-  "companies": [],
+  "companies": [
+    {
+      "name": "Desjardins",
+      "slug": "desjardins",
+      "api_url": "https://desjardins.wd10.myworkdayjobs.com/wday/cxs/desjardins/Desjardins/jobs",
+      "base_url": "https://desjardins.wd10.myworkdayjobs.com"
+    },
+    {
+      "name": "Intact Financial Corporation",
+      "slug": "intact-financial",
+      "api_url": "https://intactfc.wd3.myworkdayjobs.com/wday/cxs/intactfc/intactfc/jobs",
+      "base_url": "https://intactfc.wd3.myworkdayjobs.com"
+    },
+    {
+      "name": "CAE Inc.",
+      "slug": "cae",
+      "api_url": "https://cae.wd3.myworkdayjobs.com/wday/cxs/cae/career/jobs",
+      "base_url": "https://cae.wd3.myworkdayjobs.com"
+    },
+    {
+      "name": "McGill University",
+      "slug": "mcgill",
+      "api_url": "https://mcgill.wd3.myworkdayjobs.com/wday/cxs/mcgill/McGill_Careers/jobs",
+      "base_url": "https://mcgill.wd3.myworkdayjobs.com"
+    },
+    {
+      "name": "Cogeco",
+      "slug": "cogeco",
+      "api_url": "https://cogeco.wd3.myworkdayjobs.com/wday/cxs/cogeco/Cogeco_Careers/jobs",
+      "base_url": "https://cogeco.wd3.myworkdayjobs.com"
+    },
+    {
+      "name": "AtkinsRéalis",
+      "slug": "atkinsrealis",
+      "api_url": "https://slihrms.wd3.myworkdayjobs.com/wday/cxs/slihrms/Careers/jobs",
+      "base_url": "https://slihrms.wd3.myworkdayjobs.com"
+    },
+    {
+      "name": "Saputo Inc.",
+      "slug": "saputo",
+      "api_url": "https://saputo.wd5.myworkdayjobs.com/wday/cxs/saputo/Saputo_External_Careers/jobs",
+      "base_url": "https://saputo.wd5.myworkdayjobs.com"
+    },
+    {
+      "name": "PSP Investments",
+      "slug": "psp-investments",
+      "api_url": "https://investpsp.wd3.myworkdayjobs.com/wday/cxs/investpsp/psp_careers/jobs",
+      "base_url": "https://investpsp.wd3.myworkdayjobs.com"
+    }
+  ],
   "validation": {
     "required_fields": ["title", "_external_id"],
     "min_jobs_per_company": 0,

--- a/specs/workday/source.md
+++ b/specs/workday/source.md
@@ -33,20 +33,25 @@ The extractor paginates automatically until all jobs are fetched, capped at 500.
 
 ### Detail endpoint
 
-**URL:** `https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/job/{job-path}/details`  
+**URL:** `https://{tenant}.wd{N}.myworkdayjobs.com/wday/cxs/{tenant}/{site}/job/{job-path}`  
 **Method:** GET  
 **Auth:** None
 
 The `{job-path}` portion is derived by stripping the leading `/{site}` prefix from
-the list response's `externalPath` field. For example:
+the list response's `externalPath` field (if that prefix is present). Most real
+tenants return `externalPath` values that already start with `/job/…` and carry no
+site prefix, so no stripping is needed and the path is used verbatim. Example:
 
 ```
-externalPath = "/BellCareers/job/Montreal/Cloud-Engineer_JR-2000"
-site         = "BellCareers"   (last segment of api_url)
-job-path     = "/job/Montreal/Cloud-Engineer_JR-2000"
-detail URL   = https://bell.wd3.myworkdayjobs.com/wday/cxs/bell/BellCareers
-               /job/Montreal/Cloud-Engineer_JR-2000/details
+externalPath = "/job/Montreal/Cloud-Engineer_JR-2000"   (no site prefix)
+api_base     = https://example.wd3.myworkdayjobs.com/wday/cxs/example/ExampleCareers
+detail URL   = https://example.wd3.myworkdayjobs.com/wday/cxs/example/ExampleCareers
+               /job/Montreal/Cloud-Engineer_JR-2000
 ```
+
+Note: an older variant of the Workday CXS API appended `/details` to this URL. That
+suffix was removed because real tenants return 422 when it is present — the
+path-only URL is the correct and universally supported form.
 
 The detail response contains:
 - `jobPostingInfo.jobDescription` — full HTML job description (maps to `description_html`)

--- a/tests/test_workday_extraction.py
+++ b/tests/test_workday_extraction.py
@@ -268,7 +268,12 @@ class TestFetchWorkdayDescriptions:
 
     @pytest.mark.asyncio
     async def test_detail_url_construction(self, workday: Extractor) -> None:
-        """Detail URL strips site prefix from externalPath and appends /details."""
+        """Detail URL strips site prefix from externalPath (no /details suffix).
+
+        Real Workday tenants expose job data at the path-only URL, not at a
+        separate /details endpoint.  The site prefix in externalPath (if present)
+        is stripped so the path starts with /job/…
+        """
         raw_job: dict = {
             "externalPath": "/FixtureCareers/job/Montreal/Engineer_JR-001",
             "_api_base": "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers",
@@ -286,7 +291,7 @@ class TestFetchWorkdayDescriptions:
 
         expected_url = (
             "https://fixturecorp.wd3.myworkdayjobs.com/wday/cxs/fixturecorp/FixtureCareers"
-            "/job/Montreal/Engineer_JR-001/details"
+            "/job/Montreal/Engineer_JR-001"
         )
         mock_client.get.assert_awaited_once_with(expected_url, timeout=30.0)
 


### PR DESCRIPTION
## Summary

- Adds 8 validated Quebec-relevant Workday employers to `specs/workday/schema.json`
- Fixes a compatibility bug in the Workday detail-URL construction (removes the erroneous `/details` suffix that causes all real Workday tenants to return 422)
- Updates `specs/workday/source.md` to document the correct URL format
- Updates `tests/test_workday_extraction.py` to match the corrected URL

## Companies added

| Slug | Display name | Workday tenant |
|------|-------------|----------------|
| `desjardins` | Desjardins | `desjardins.wd10.myworkdayjobs.com` |
| `intact-financial` | Intact Financial Corporation | `intactfc.wd3.myworkdayjobs.com` |
| `cae` | CAE Inc. | `cae.wd3.myworkdayjobs.com` |
| `mcgill` | McGill University | `mcgill.wd3.myworkdayjobs.com` |
| `cogeco` | Cogeco | `cogeco.wd3.myworkdayjobs.com` |
| `atkinsrealis` | AtkinsRéalis (formerly SNC-Lavalin) | `slihrms.wd3.myworkdayjobs.com` |
| `saputo` | Saputo Inc. | `saputo.wd5.myworkdayjobs.com` |
| `psp-investments` | PSP Investments | `investpsp.wd3.myworkdayjobs.com` |

## Verification

```bash
# All 277 tests pass
pytest  # 277 passed in 0.29s

# Dry-run: 297 jobs extracted, zero errors
python -m pipeline.extractor workday
# fetched company=Desjardins count=40
# fetched company='Intact Financial Corporation' count=40
# fetched company='CAE Inc.' count=39
# fetched company='McGill University' count=39
# fetched company=Cogeco count=35
# fetched company=AtkinsRéalis count=40
# fetched company='Saputo Inc.' count=37
# fetched company='PSP Investments' count=27
# extraction_complete source=workday total=297

# No duplicate slugs (51 total companies across all ATSs)
```

## Researched but not added

| Candidate | Reason not added |
|-----------|-----------------|
| Bell Canada | Uses Taleo (`jobs.bce.ca` / `aircanada.taleo.net` pattern); Taleo is excluded per spec |
| Hydro-Québec | Uses own portal (`emploi.hydroquebec.com`), not Workday |
| Air Canada | Uses Taleo (`aircanada.taleo.net`) |
| Ubisoft | Uses SmartRecruiters, not Workday |
| WSP Global | Uses Oracle Fusion (oraclecloud.com), not Workday |
| BRP | Custom careers portal (`careers.brp.com`); no direct `myworkdayjobs.com` URL found |
| Bombardier | Uses `jobs.bombardier.com`, not Workday |
| Metro Inc. | Uses own portal (`talent.metro.ca`), not Workday |
| National Bank | Uses custom Workday domain (`emplois.bnc.ca`) but underlying `myworkdayjobs.com` API URL not discoverable |
| Université de Montréal | Uses own system (`usagers.umontreal.ca`), not Workday |
| CGI | Uses own portal (`cgi.jobs`), not Workday |

## Open questions / risks

- **AtkinsRéalis** has ~1977 total jobs globally; the pagination cap (500) limits the fetch. Quebec jobs will be included in the 500 fetched since the `is_qc` derivation filters at extraction time.
- **Detail URL fix**: the legacy `/details` suffix was documented in `source.md` (issue #74) but returns 422 on all tested real tenants. The path-only URL is correct and confirmed working. The fix is backward-compatible — the fixture test was using a mock client so it never caught this.

Closes #75