### PR TITLE
feat: add contextual facet counts

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -62,6 +62,21 @@ interface DbStats {
   last_updated:     string | null;
 }
 
+// Contextual facet counts — each facet excludes its own active filter so the
+// count for value V reflects "how many jobs match active filters + V".
+interface FacetCounts {
+  sourceCounts:    Record<string, number>;
+  seniorityCounts: Record<string, number>;
+  workplaceCounts: Record<string, number>;
+}
+
+// Shape returned by the get_contextual_facets() Supabase RPC.
+interface DbFacetCounts {
+  source_counts:    Record<string, number>;
+  seniority_counts: Record<string, number>;
+  workplace_counts: Record<string, number>;
+}
+
 async function fetchJobs(filters: SearchParams): Promise<{ jobs: Job[]; total: number }> {
   const page = Math.max(1, parseInt(filters.page ?? "1", 10));
   const from = (page - 1) * PAGE_SIZE;
@@ -124,6 +139,31 @@ async function fetchStats(): Promise<Stats> {
   };
 }
 
+// Calls the get_contextual_facets() Supabase RPC.
+// Each facet count is computed with all OTHER active filters applied — never
+// double-counting the facet's own filter — so counts reflect what the user
+// would get by clicking that value.  All NULL params → global totals.
+async function fetchContextualFacets(filters: SearchParams): Promise<FacetCounts> {
+  const { data, error } = await supabase.rpc("get_contextual_facets", {
+    p_tech:      filters.tech      ?? null,
+    p_source:    filters.source    ?? null,
+    p_remote:    filters.remote    ?? null,
+    p_seniority: filters.seniority ?? null,
+  });
+
+  if (error) {
+    console.error("[fetchContextualFacets] RPC error:", error.message);
+    return { sourceCounts: {}, seniorityCounts: {}, workplaceCounts: {} };
+  }
+
+  const db = (data ?? {}) as DbFacetCounts;
+  return {
+    sourceCounts:    db.source_counts    ?? {},
+    seniorityCounts: db.seniority_counts ?? {},
+    workplaceCounts: db.workplace_counts ?? {},
+  };
+}
+
 export default async function Page({
   searchParams,
 }: {
@@ -132,10 +172,22 @@ export default async function Page({
   const filters = await searchParams;
   const page    = Math.max(1, parseInt(filters.page ?? "1", 10));
 
-  const [{ jobs, total }, stats] = await Promise.all([
+  const [{ jobs, total }, stats, facets] = await Promise.all([
     fetchJobs(filters),
     fetchStats(),
+    fetchContextualFacets(filters),
   ]);
+
+  // Ensure every known source and workplace option has an explicit count (0 if
+  // the combination yields no results) so FilterChip always shows a number.
+  const sourceCounts = Object.fromEntries(
+    stats.sourceOptions.map((s) => [s, facets.sourceCounts[s] ?? 0])
+  );
+  const workplaceCounts: Record<string, number> = {
+    "true":  facets.workplaceCounts["true"]  ?? 0,
+    "false": facets.workplaceCounts["false"] ?? 0,
+    "null":  facets.workplaceCounts["null"]  ?? 0,
+  };
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
   const hasFilters = !!(filters.tech || filters.source || filters.remote || filters.seniority);
@@ -173,9 +225,9 @@ export default async function Page({
           <FilterSidebar
             techOptions={stats.techOptions}
             sourceOptions={stats.sourceOptions}
-            sourceCounts={stats.sourceCounts}
-            seniorityCounts={stats.seniorityCounts}
-            workplaceCounts={stats.workplaceCounts}
+            sourceCounts={sourceCounts}
+            seniorityCounts={facets.seniorityCounts}
+            workplaceCounts={workplaceCounts}
           />
         </Suspense>
 
@@ -215,9 +267,9 @@ export default async function Page({
             <MobileFilterDrawer
               techOptions={stats.techOptions}
               sourceOptions={stats.sourceOptions}
-              sourceCounts={stats.sourceCounts}
-              seniorityCounts={stats.seniorityCounts}
-              workplaceCounts={stats.workplaceCounts}
+              sourceCounts={sourceCounts}
+              seniorityCounts={facets.seniorityCounts}
+              workplaceCounts={workplaceCounts}
               activeFilterCount={activeFilterCount}
             />
           </Suspense>

--- a/scripts/migrate_contextual_facets_rpc.sql
+++ b/scripts/migrate_contextual_facets_rpc.sql
@@ -1,0 +1,121 @@
+-- Jobs Radar QC — contextual facet counts RPC (issue #30)
+-- Creates get_contextual_facets(), a DB-side aggregation function that returns
+-- source, workplace, and seniority counts reflecting the currently active
+-- filters rather than global totals.
+--
+-- Semantics (mutually-exclusive / replacement):
+--   For each candidate value V in facet F, count =
+--     COUNT WHERE (all active filters except F) AND F = V
+--
+-- This means:
+--   source_counts    → applies tech + remote + seniority filters, NOT source
+--   workplace_counts → applies tech + source + seniority filters, NOT remote
+--   seniority_counts → applies tech + source + remote filters,    NOT seniority
+--
+-- Called with all NULL params → returns identical counts to get_homepage_stats(),
+-- so it is safe to call unconditionally regardless of filter state.
+--
+-- Run after migrate.sql and migrate_enrichment.sql.
+-- Safe to re-run: CREATE OR REPLACE + idempotent GRANT.
+--
+-- HOW TO APPLY
+-- In Supabase SQL Editor: paste and run this file in one shot.
+-- In psql: \i scripts/migrate_contextual_facets_rpc.sql
+--
+-- VALIDATION
+--   SELECT get_contextual_facets(NULL, NULL, NULL, NULL);
+--   -- → global counts, matches get_homepage_stats() source/workplace/seniority_counts
+--
+--   SELECT get_contextual_facets('TypeScript', NULL, NULL, NULL);
+--   -- → counts scoped to TypeScript jobs; source/workplace/seniority breakdown
+--   --   should sum to the same total as fetchJobs({tech:'TypeScript'}) returns.
+--
+-- NOTE ON tech_stack CONTAINMENT
+-- tech_stack @> ARRAY[p_tech] on the active_qc_jobs view performs a sequential
+-- scan because the view computes a merged array expression that the base-table
+-- GIN index cannot satisfy (see migrate_indexes.sql for the full explanation).
+-- At current dataset sizes (< 5 000 rows) this is acceptable.
+
+CREATE OR REPLACE FUNCTION get_contextual_facets(
+  p_tech      text DEFAULT NULL,
+  p_source    text DEFAULT NULL,
+  p_remote    text DEFAULT NULL,   -- 'true' | 'false' | 'null' | NULL (no filter)
+  p_seniority text DEFAULT NULL
+)
+RETURNS json
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+AS $$
+  SELECT json_build_object(
+
+    -- Source counts: apply tech + remote + seniority filters, NOT source.
+    -- Each entry shows how many jobs match the other active filters + that source.
+    'source_counts', (
+      SELECT COALESCE(json_object_agg(source, cnt), '{}'::json)
+      FROM (
+        SELECT source, COUNT(*) AS cnt
+        FROM   active_qc_jobs
+        WHERE  source IS NOT NULL
+          AND  (p_tech      IS NULL OR tech_stack @> ARRAY[p_tech])
+          AND  (p_seniority IS NULL OR seniority = p_seniority)
+          AND  (
+                 p_remote IS NULL OR
+                 CASE p_remote
+                   WHEN 'true'  THEN is_remote IS TRUE
+                   WHEN 'false' THEN is_remote IS FALSE
+                   WHEN 'null'  THEN is_remote IS NULL
+                   ELSE TRUE
+                 END
+               )
+        GROUP  BY source
+      ) s
+    ),
+
+    -- Workplace counts: apply tech + source + seniority filters, NOT remote.
+    -- Keys match FilterSidebar's 'true' / 'false' / 'null' convention.
+    'workplace_counts', (
+      SELECT COALESCE(json_object_agg(is_remote_key, cnt), '{}'::json)
+      FROM (
+        SELECT
+          CASE
+            WHEN is_remote IS TRUE  THEN 'true'
+            WHEN is_remote IS FALSE THEN 'false'
+            ELSE                        'null'
+          END AS is_remote_key,
+          COUNT(*) AS cnt
+        FROM   active_qc_jobs
+        WHERE  (p_tech      IS NULL OR tech_stack @> ARRAY[p_tech])
+          AND  (p_source    IS NULL OR source = p_source)
+          AND  (p_seniority IS NULL OR seniority = p_seniority)
+        GROUP  BY 1
+      ) s
+    ),
+
+    -- Seniority counts: apply tech + source + remote filters, NOT seniority.
+    'seniority_counts', (
+      SELECT COALESCE(json_object_agg(seniority, cnt), '{}'::json)
+      FROM (
+        SELECT seniority, COUNT(*) AS cnt
+        FROM   active_qc_jobs
+        WHERE  seniority IS NOT NULL
+          AND  (p_tech   IS NULL OR tech_stack @> ARRAY[p_tech])
+          AND  (p_source IS NULL OR source = p_source)
+          AND  (
+                 p_remote IS NULL OR
+                 CASE p_remote
+                   WHEN 'true'  THEN is_remote IS TRUE
+                   WHEN 'false' THEN is_remote IS FALSE
+                   WHEN 'null'  THEN is_remote IS NULL
+                   ELSE TRUE
+                 END
+               )
+        GROUP  BY seniority
+      ) s
+    )
+
+  );
+$$;
+
+-- Allow the frontend (anon key) and authenticated users to call this function.
+GRANT EXECUTE ON FUNCTION get_contextual_facets(text, text, text, text) TO anon, authenticated;


### PR DESCRIPTION
## Summary

- Adds `get_contextual_facets(p_tech, p_source, p_remote, p_seniority)` SQL RPC that returns facet counts scoped to the currently active filters
- Each facet excludes its own active filter, so counts reflect "how many jobs would match if I clicked this value" — standard faceted-search semantics
- Wires the new RPC into `page.tsx` via a parallel `fetchContextualFacets()` call alongside the existing `fetchStats()` / `fetchJobs()` calls
- Both desktop `FilterSidebar` and mobile `MobileFilterDrawer` receive contextual counts with no interface changes required
- Zero-result combinations show explicit `0` counts for Source and Workplace; Seniority options with `0` contextual results are hidden (matches existing behavior)

## Count semantics implemented

- **Source** — applies `tech + remote + seniority` filters, groups by `source`
- **Workplace** — applies `tech + source + seniority` filters, groups by `is_remote`
- **Seniority** — applies `tech + source + remote` filters, groups by `seniority`
- Facets are mutually-exclusive / replacement: count for value V = jobs matching `(all active filters except this facet) AND this_facet = V`
- Called with all-NULL params (no filters) → returns identical totals to the global `get_homepage_stats()` counts, so behavior is unchanged when no filters are active

## SQL / RPC migration notes

A new SQL file must be applied to Supabase before this PR is deployed:

```
scripts/migrate_contextual_facets_rpc.sql
```

Run in Supabase SQL Editor (paste and run in one shot) or:

```bash
psql $DATABASE_URL -f scripts/migrate_contextual_facets_rpc.sql
```

Validation queries (run after applying):
```sql
SELECT get_contextual_facets(NULL, NULL, NULL, NULL);
-- → same counts as get_homepage_stats() source/workplace/seniority_counts

SELECT get_contextual_facets('TypeScript', NULL, NULL, NULL);
-- → counts scoped to TypeScript jobs only
```

## Verification commands

```bash
cd frontend
npx tsc --noEmit   # ✓ 0 errors
npm run lint       # ✓ 0 warnings
```

## Manual filter scenarios tested

| Scenario | Expected behaviour |
|---|---|
| No filters active | Counts match global totals (all-NULL params = global) |
| `tech=TypeScript` | Source / Workplace / Seniority counts update to TypeScript subset |
| `source=greenhouse` | Workplace / Seniority counts scoped to greenhouse; other source counts show how many lever / workable jobs also match remaining filters |
| `seniority=senior` | Source / Workplace counts scoped to senior roles |
| Two filters combined | Each facet drops both non-facet filters; counts remain accurate |
| Zero-result combination | Source / Workplace show `0`; Seniority option hidden |
| Pagination | Unaffected — `fetchJobs` is unchanged |
| Mobile FilterDrawer | Receives same contextual props; no interface change needed |

Closes #30