### PR TITLE
fix: make homepage filter sidebar sticky

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -208,7 +208,7 @@ export default async function Page({
     <div className="mx-auto flex w-full max-w-7xl flex-1 px-4 py-6">
       {/* ── Desktop sidebar ───────────────────────────────────────────── */}
       <aside
-        className="hidden w-56 shrink-0 pr-6 lg:block"
+        className="hidden w-56 shrink-0 pr-6 lg:block sticky top-4 self-start max-h-[calc(100vh-2rem)] overflow-y-auto"
         aria-label="Filter panel"
       >
         {/* Sidebar header */}


### PR DESCRIPTION
## Summary

- Added `sticky top-4 self-start` to the desktop `<aside>` wrapper in `app/page.tsx` so the filter panel stays in view while scrolling the job grid.
- Added `max-h-[calc(100vh-2rem)] overflow-y-auto` so the sidebar scrolls internally when all filter sections are expanded and exceed the viewport height.
- Desktop-only change (`lg:block` aside) — `MobileFilterDrawer` and mobile layout are completely unaffected.

## Verification commands

```bash
cd frontend && npm run lint    # passed — no errors
cd frontend && npm run build   # passed — TypeScript clean, all 8 pages generated
```

## Manual viewport checks

| Viewport | Expected |
|---|---|
| 1440px desktop | Sidebar sticks while scrolling job grid |
| 1024px desktop | Sidebar sticks, does not overlap top nav |
| Expanded filters | Sidebar scrolls internally within `max-h` |
| 375px mobile | Drawer behavior unchanged, no sticky sidebar visible |

## Files changed

- `frontend/app/page.tsx` — one-line className update on the `<aside>` element

Closes #88