### PR TITLE
fix: label radar category leaders

### DIFF
--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -53,8 +53,6 @@ function RadarChart({
   const CX = 280, CY = 240, R = 200;
   const RINGS = [0.95, 0.68, 0.42, 0.18];
   const RING_LABELS = ["top 5", "top 10", "top 20", "long tail"];
-  /** Top-5 techs globally — used to decide inline label rendering. */
-  const TOP5 = new Set(allTechs.slice(0, 5).map((t) => t.name));
 
   /* ── Group techs by selected sector, capped at 8 per sector ──────────── */
   const byCat: Record<string, TechRow[]> = {};
@@ -68,13 +66,21 @@ function RadarChart({
     }
   }
 
+  /* ── One label per active sector: highest-count tech in each category ── */
+  const CATEGORY_LEADERS = new Set(
+    selectedCats.flatMap((cat) => {
+      const leader = byCat[cat]?.[0];
+      return leader ? [leader.name] : [];
+    }),
+  );
+
   /* ── Place tech bubbles in polar coordinates ─────────────────────────── */
   interface PlacedTech {
     tech: TechRow;
     x: number;
     y: number;
     size: number;
-    isTop5: boolean;
+    isCategoryLeader: boolean;
     labelSide: "right" | "left";
   }
 
@@ -96,10 +102,10 @@ function RadarChart({
       const x = CX + Math.cos(angle) * r;
       const y = CY + Math.sin(angle) * r;
       const size = Math.max(6, Math.min(20, Math.sqrt(tech.count) * 1.3));
-      const isTop5 = TOP5.has(tech.name);
+      const isCategoryLeader = CATEGORY_LEADERS.has(tech.name);
       const labelSide = x > CX ? "right" : "left";
 
-      placed.push({ tech, x, y, size, isTop5, labelSide });
+      placed.push({ tech, x, y, size, isCategoryLeader, labelSide });
     });
   });
 
@@ -214,10 +220,10 @@ function RadarChart({
       />
 
       {/* Bubbles — colored by category token */}
-      {placed.map(({ tech, x, y, size, isTop5, labelSide }) => {
+      {placed.map(({ tech, x, y, size, isCategoryLeader, labelSide }) => {
         const cssSlug = catToCssSlug(tech.category);
         const catColor = `var(--cat-${cssSlug}, var(--accent))`;
-        const bubbleFill = isTop5
+        const bubbleFill = isCategoryLeader
           ? catColor
           : `color-mix(in oklab, ${catColor} 35%, var(--surface))`;
         return (
@@ -235,8 +241,8 @@ function RadarChart({
                 strokeWidth="1"
                 style={{ cursor: "pointer" }}
               />
-              {/* Inline labels for top-5 only; others surface via <title> tooltip */}
-              {isTop5 && (
+              {/* Inline label for category leader only; others surface via <title> tooltip */}
+              {isCategoryLeader && (
                 <>
                   <text
                     x={labelSide === "right" ? x + size + 4 : x - size - 4}

--- a/frontend/lib/radarHelpers.ts
+++ b/frontend/lib/radarHelpers.ts
@@ -262,7 +262,6 @@ export function renderRadarSvg(
   const CX = 280, CY = 240, R = 200;
   const RINGS = [0.95, 0.68, 0.42, 0.18];
   const RING_LABELS = ["top 5", "top 10", "top 20", "long tail"];
-  const TOP5 = new Set(allTechs.slice(0, 5).map((t) => t.name));
 
   /* ── Group techs by sector, capped at 8 per sector ─────────────────── */
   const byCat: Record<string, TechRow[]> = {};
@@ -272,13 +271,21 @@ export function renderRadarSvg(
     if (arr && arr.length < 8) arr.push(t);
   }
 
+  /* ── One label per active sector: highest-count tech in each category ── */
+  const CATEGORY_LEADERS = new Set(
+    selectedCats.flatMap((cat) => {
+      const leader = byCat[cat]?.[0];
+      return leader ? [leader.name] : [];
+    }),
+  );
+
   /* ── Polar placement ────────────────────────────────────────────────── */
   interface Placed {
     tech: TechRow;
     x: number;
     y: number;
     size: number;
-    isTop5: boolean;
+    isCategoryLeader: boolean;
     labelSide: "right" | "left";
     color: string;
   }
@@ -297,10 +304,10 @@ export function renderRadarSvg(
       const x = CX + Math.cos(angle) * r;
       const y = CY + Math.sin(angle) * r;
       const size = Math.max(6, Math.min(20, Math.sqrt(tech.count) * 1.3));
-      const isTop5 = TOP5.has(tech.name);
+      const isCategoryLeader = CATEGORY_LEADERS.has(tech.name);
       const labelSide: "right" | "left" = x > CX ? "right" : "left";
       const color = CAT_COLORS[cat] ?? "#888888";
-      placed.push({ tech, x, y, size, isTop5, labelSide, color });
+      placed.push({ tech, x, y, size, isCategoryLeader, labelSide, color });
     });
   });
 
@@ -366,9 +373,9 @@ export function renderRadarSvg(
   );
 
   // Bubbles
-  for (const { tech, x, y, size, isTop5, labelSide, color } of placed) {
-    // Top-5: solid fill; others: ~35% opacity (hex 59 ≈ 35% of 255)
-    const fill = isTop5 ? color : `${color}59`;
+  for (const { tech, x, y, size, isCategoryLeader, labelSide, color } of placed) {
+    // Category leader: solid fill; others: ~35% opacity (hex 59 ≈ 35% of 255)
+    const fill = isCategoryLeader ? color : `${color}59`;
     const labelX = labelSide === "right" ? x + size + 4 : x - size - 4;
     const anchor = labelSide === "right" ? "start" : "end";
     parts.push(
@@ -376,7 +383,7 @@ export function renderRadarSvg(
         `<title>${escSvg(tech.name)} — ${tech.count} roles (rank #${tech.rank})</title>` +
         `</circle>`,
     );
-    if (isTop5) {
+    if (isCategoryLeader) {
       parts.push(
         `<text x="${n(labelX)}" y="${n(y + 3)}" font-family="sans-serif" font-size="10.5" font-weight="600" text-anchor="${anchor}" fill="#c9d1d9">${escSvg(tech.name)}</text>`,
       );


### PR DESCRIPTION
## Summary

- Replaces the global `TOP5` set (first 5 techs across all categories) with a `CATEGORY_LEADERS` set containing exactly one tech per active radar sector: the highest-count technology in that category under the current filters.
- With 4 selected sectors the radar now shows exactly 4 labels, evenly distributed — one per sector.
- Applies to both the JSX `RadarChart` component in `app/trends/page.tsx` and the standalone `renderRadarSvg` helper in `lib/radarHelpers.ts` (used by `/api/radar?format=svg`).

## Category-leader logic

After `byCat` is built (filtered data grouped by selected category, capped at 8 per sector):

```ts
const CATEGORY_LEADERS = new Set(
  selectedCats.flatMap((cat) => {
    const leader = byCat[cat]?.[0]; // first = highest-count after filters
    return leader ? [leader.name] : [];
  }),
);
```

`allTechs` is already sorted by count descending (from `fetchRadarData`), so `byCat[cat][0]` is deterministically the highest-count tech in that category for the current `window` + `segment` + `cats` combination. Categories with no matching techs produce no label.

## Verification commands

```bash
cd frontend
npx tsc --noEmit   # ✅ no errors
npm run lint       # ✅ no errors
```

## Manual filter combinations tested

| Filter combination | Expected labels |
|---|---|
| Default (`cats=languages,frontend,devops,data_ai`) | Top language, top frontend, top DevOps, top Data/AI |
| `cats=languages,backend,testing,mobile` | Top tech in each of those 4 sectors |
| `segment=ai_ml` | Leaders computed from AI/ML-filtered data only |
| `window=7d` | Leaders computed from 7-day window data only |
| Category with no matching techs | No label for that sector |

## Files changed

- `frontend/app/trends/page.tsx` — `RadarChart` component: `TOP5` → `CATEGORY_LEADERS`, `isTop5` → `isCategoryLeader`
- `frontend/lib/radarHelpers.ts` — `renderRadarSvg` function: same replacement

Closes #89