### PR TITLE
feat: add radar bubble tooltips

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -210,3 +210,4 @@ body {
     width: 30% !important; /* static partial fill — visible but not moving */
   }
 }
+

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -4,11 +4,7 @@ import { SHARED_OG } from "@/lib/siteMetadata";
 import { Suspense } from "react";
 import {
   CANONICAL,
-  CATEGORY_LABELS,
   DEFAULT_CATS,
-  type CatSlug,
-  type TechRow,
-  catToCssSlug,
   parseCatsParam,
 } from "@/lib/radarHelpers";
 import {
@@ -22,6 +18,7 @@ import {
 } from "@/lib/segmentHelpers";
 import { RadarBgContainer } from "@/components/RadarBgContainer";
 import { RadarCategorySelector } from "@/components/RadarCategorySelector";
+import { RadarChartClient } from "@/components/RadarChartClient";
 import { RadarDownloadPanel } from "@/components/RadarDownloadPanel";
 import { SegmentFilter } from "@/components/SegmentFilter";
 
@@ -42,250 +39,6 @@ export const metadata: Metadata = {
 };
 
 export const revalidate = 3600;
-
-/* ── Radar SVG ──────────────────────────────────────────────────────────── */
-function RadarChart({
-  allTechs,
-  selectedCats,
-}: {
-  allTechs: TechRow[];
-  selectedCats: string[];
-}) {
-  const CX = 280, CY = 240, R = 200;
-  const RINGS = [0.95, 0.68, 0.42, 0.18];
-  const RING_LABELS = ["top 5", "top 10", "top 20", "long tail"];
-
-  /* ── Group techs by selected sector, capped at 8 per sector ──────────── */
-  const byCat: Record<string, TechRow[]> = {};
-  for (const cat of selectedCats) {
-    byCat[cat] = [];
-  }
-  for (const t of allTechs) {
-    const arr = byCat[t.category];
-    if (arr && arr.length < 8) {
-      arr.push(t);
-    }
-  }
-
-  /* ── One label per active sector: highest-count tech in each category ── */
-  const CATEGORY_LEADERS = new Set(
-    selectedCats.flatMap((cat) => {
-      const leader = byCat[cat]?.[0];
-      return leader ? [leader.name] : [];
-    }),
-  );
-
-  /* ── Place tech bubbles in polar coordinates ─────────────────────────── */
-  interface PlacedTech {
-    tech: TechRow;
-    x: number;
-    y: number;
-    size: number;
-    isCategoryLeader: boolean;
-    labelSide: "right" | "left";
-  }
-
-  const placed: PlacedTech[] = [];
-
-  selectedCats.forEach((cat, catIdx) => {
-    const arr = byCat[cat] ?? [];
-    const sectorAngle = (Math.PI * 2) / selectedCats.length;
-    arr.forEach((tech, i) => {
-      const angle =
-        -Math.PI / 2 +
-        catIdx * sectorAngle +
-        (sectorAngle * (i + 1)) / (arr.length + 1);
-
-      // Rank drives radial position: top rank closer to center
-      const rankFrac = tech.rank / Math.max(1, allTechs.length);
-      const r = R * (0.16 + 0.76 * Math.min(1, rankFrac * 1.8));
-
-      const x = CX + Math.cos(angle) * r;
-      const y = CY + Math.sin(angle) * r;
-      const size = Math.max(6, Math.min(20, Math.sqrt(tech.count) * 1.3));
-      const isCategoryLeader = CATEGORY_LEADERS.has(tech.name);
-      const labelSide = x > CX ? "right" : "left";
-
-      placed.push({ tech, x, y, size, isCategoryLeader, labelSide });
-    });
-  });
-
-  /* ── Total tech count for aria desc ─────────────────────────────────── */
-  const visibleCount = placed.length;
-
-  return (
-    <svg
-      viewBox="0 0 560 480"
-      style={{ width: "100%", height: "100%", display: "block" }}
-      role="img"
-      aria-label="Tech stack radial radar showing technology distribution across Quebec tech jobs"
-    >
-      <title>Tech Stack Radar — Jobs Radar /qc</title>
-      <desc>
-        Radial chart showing {visibleCount} technologies grouped into{" "}
-        {selectedCats.length} sectors:{" "}
-        {selectedCats
-          .map((c) => CATEGORY_LABELS[c as CatSlug] ?? c)
-          .join(", ")}
-        . Bubble size represents posting count; proximity to center represents
-        overall rank.
-      </desc>
-
-      {/* Concentric rings */}
-      {RINGS.map((k, i) => (
-        <g key={i}>
-          <circle
-            cx={CX}
-            cy={CY}
-            r={R * k}
-            fill="none"
-            stroke="var(--rule-soft)"
-            strokeDasharray="3 5"
-            strokeWidth="1"
-          />
-          <text
-            x={CX + R * k + 5}
-            y={CY - 5}
-            fontFamily="var(--font-mono)"
-            fontSize="9"
-            fill="var(--ink-mute)"
-          >
-            {RING_LABELS[i]}
-          </text>
-        </g>
-      ))}
-
-      {/* Sector divider lines */}
-      {selectedCats.map((_, i) => {
-        const sector = (Math.PI * 2) / selectedCats.length;
-        const a0 = -Math.PI / 2 + i * sector;
-        return (
-          <line
-            key={i}
-            x1={CX}
-            y1={CY}
-            x2={CX + Math.cos(a0) * R}
-            y2={CY + Math.sin(a0) * R}
-            stroke="var(--rule-soft)"
-            strokeWidth="1"
-          />
-        );
-      })}
-
-      {/* Sector labels — colored by category token */}
-      {selectedCats.map((cat, i) => {
-        const sector = (Math.PI * 2) / selectedCats.length;
-        const am = -Math.PI / 2 + i * sector + sector / 2;
-        const lx = CX + Math.cos(am) * (R + 26);
-        const ly = CY + Math.sin(am) * (R + 26);
-        const cssSlug = catToCssSlug(cat);
-        const label = CATEGORY_LABELS[cat as CatSlug] ?? cat;
-        return (
-          <text
-            key={cat}
-            x={lx}
-            y={ly}
-            fontFamily="var(--font-sans)"
-            fontSize="11"
-            fontWeight="600"
-            textAnchor="middle"
-            fill={`var(--cat-${cssSlug})`}
-          >
-            {label}
-          </text>
-        );
-      })}
-
-      {/* Decorative sweep line at -32° */}
-      <line
-        x1={CX}
-        y1={CY}
-        x2={CX + R}
-        y2={CY}
-        stroke="var(--accent)"
-        strokeWidth="1.25"
-        strokeDasharray="2 5"
-        opacity="0.45"
-        transform={`rotate(-32 ${CX} ${CY})`}
-      />
-
-      {/* Center dot */}
-      <circle cx={CX} cy={CY} r={5} fill="var(--accent)" />
-      <circle
-        cx={CX}
-        cy={CY}
-        r={13}
-        fill="none"
-        stroke="var(--accent)"
-        strokeWidth="1"
-      />
-
-      {/* Bubbles — colored by category token */}
-      {placed.map(({ tech, x, y, size, isCategoryLeader, labelSide }) => {
-        const cssSlug = catToCssSlug(tech.category);
-        const catColor = `var(--cat-${cssSlug}, var(--accent))`;
-        const bubbleFill = isCategoryLeader
-          ? catColor
-          : `color-mix(in oklab, ${catColor} 35%, var(--surface))`;
-        return (
-          <g key={tech.name}>
-            <title>
-              {tech.name} — {tech.count} roles (rank #{tech.rank})
-            </title>
-            <a href={`/?tech=${encodeURIComponent(tech.name)}`}>
-              <circle
-                cx={x}
-                cy={y}
-                r={size}
-                fill={bubbleFill}
-                stroke="var(--rule-soft)"
-                strokeWidth="1"
-                style={{ cursor: "pointer" }}
-              />
-              {/* Inline label for category leader only; others surface via <title> tooltip */}
-              {isCategoryLeader && (
-                <>
-                  <text
-                    x={labelSide === "right" ? x + size + 4 : x - size - 4}
-                    y={y + 3}
-                    fontFamily="var(--font-sans)"
-                    fontSize="10.5"
-                    fontWeight="600"
-                    textAnchor={labelSide === "right" ? "start" : "end"}
-                    fill="var(--ink)"
-                  >
-                    {tech.name}
-                  </text>
-                  <text
-                    x={labelSide === "right" ? x + size + 4 : x - size - 4}
-                    y={y + 14}
-                    fontFamily="var(--font-mono)"
-                    fontSize="8.5"
-                    textAnchor={labelSide === "right" ? "start" : "end"}
-                    fill="var(--ink-mute)"
-                  >
-                    {tech.count}
-                  </text>
-                </>
-              )}
-            </a>
-          </g>
-        );
-      })}
-
-      {/* Legend */}
-      <text
-        x="16"
-        y="470"
-        fontFamily="var(--font-mono)"
-        fontSize="9"
-        fill="var(--ink-mute)"
-      >
-        ◯ size = job count · proximity to center = rank · hover for name
-      </text>
-    </svg>
-  );
-}
 
 /* ── Page ───────────────────────────────────────────────────────────────── */
 export default async function TrendsPage({
@@ -385,7 +138,7 @@ export default async function TrendsPage({
               </div>
             </div>
           ) : (
-            <RadarChart allTechs={allTechs} selectedCats={selectedCats} />
+            <RadarChartClient allTechs={allTechs} selectedCats={selectedCats} />
           )}
         </RadarBgContainer>
       </div>

--- a/frontend/components/RadarChartClient.tsx
+++ b/frontend/components/RadarChartClient.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  CATEGORY_LABELS,
+  type CatSlug,
+  type TechRow,
+  catToCssSlug,
+} from "@/lib/radarHelpers";
+
+const CX = 280, CY = 240, R = 200;
+const RINGS = [0.95, 0.68, 0.42, 0.18];
+const RING_LABELS = ["top 5", "top 10", "top 20", "long tail"];
+
+interface TooltipState {
+  name: string;
+  count: number;
+  category: string;
+  /** SVG viewBox coordinates — converted to % for CSS positioning */
+  vx: number;
+  vy: number;
+}
+
+export function RadarChartClient({
+  allTechs,
+  selectedCats,
+}: {
+  allTechs: TechRow[];
+  selectedCats: string[];
+}) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const [focusedBubble, setFocusedBubble] = useState<string | null>(null);
+  const router = useRouter();
+
+  /* ── Group techs by sector, capped at 8 per sector ──────────────────── */
+  const byCat: Record<string, TechRow[]> = {};
+  for (const cat of selectedCats) byCat[cat] = [];
+  for (const t of allTechs) {
+    const arr = byCat[t.category];
+    if (arr && arr.length < 8) arr.push(t);
+  }
+
+  const CATEGORY_LEADERS = new Set(
+    selectedCats.flatMap((cat) => {
+      const leader = byCat[cat]?.[0];
+      return leader ? [leader.name] : [];
+    }),
+  );
+
+  interface PlacedTech {
+    tech: TechRow;
+    x: number;
+    y: number;
+    size: number;
+    isCategoryLeader: boolean;
+    labelSide: "right" | "left";
+  }
+
+  const placed: PlacedTech[] = [];
+  selectedCats.forEach((cat, catIdx) => {
+    const arr = byCat[cat] ?? [];
+    const sectorAngle = (Math.PI * 2) / selectedCats.length;
+    arr.forEach((tech, i) => {
+      const angle =
+        -Math.PI / 2 +
+        catIdx * sectorAngle +
+        (sectorAngle * (i + 1)) / (arr.length + 1);
+      const rankFrac = tech.rank / Math.max(1, allTechs.length);
+      const r = R * (0.16 + 0.76 * Math.min(1, rankFrac * 1.8));
+      const x = CX + Math.cos(angle) * r;
+      const y = CY + Math.sin(angle) * r;
+      const size = Math.max(6, Math.min(20, Math.sqrt(tech.count) * 1.3));
+      const isCategoryLeader = CATEGORY_LEADERS.has(tech.name);
+      const labelSide = x > CX ? "right" : "left";
+      placed.push({ tech, x, y, size, isCategoryLeader, labelSide });
+    });
+  });
+
+  const visibleCount = placed.length;
+
+  function navigate(techName: string) {
+    router.push(`/?tech=${encodeURIComponent(techName)}`);
+  }
+
+  function showTooltip(tech: TechRow, x: number, y: number) {
+    const catLabel = CATEGORY_LABELS[tech.category as CatSlug] ?? tech.category;
+    setTooltip({ name: tech.name, count: tech.count, category: catLabel, vx: x, vy: y });
+  }
+
+  function hideTooltip() {
+    setTooltip(null);
+  }
+
+  // Position tooltip above the bubble by default; flip below if near the top.
+  const nearTop = tooltip !== null && tooltip.vy < 60;
+  const tooltipTransform = nearTop
+    ? "translate(-50%, 12px)"
+    : "translate(-50%, calc(-100% - 10px))";
+
+  return (
+    <div style={{ position: "relative", width: "100%", height: "100%" }}>
+      <svg
+        viewBox="0 0 560 480"
+        style={{ width: "100%", height: "100%", display: "block" }}
+        role="img"
+        aria-label="Tech stack radial radar showing technology distribution across Quebec tech jobs"
+      >
+        <title>Tech Stack Radar — Jobs Radar /qc</title>
+        <desc>
+          Radial chart showing {visibleCount} technologies grouped into{" "}
+          {selectedCats.length} sectors:{" "}
+          {selectedCats
+            .map((c) => CATEGORY_LABELS[c as CatSlug] ?? c)
+            .join(", ")}
+          . Bubble size represents posting count; proximity to center represents
+          overall rank.
+        </desc>
+
+        {/* Concentric rings */}
+        {RINGS.map((k, i) => (
+          <g key={i}>
+            <circle
+              cx={CX}
+              cy={CY}
+              r={R * k}
+              fill="none"
+              stroke="var(--rule-soft)"
+              strokeDasharray="3 5"
+              strokeWidth="1"
+            />
+            <text
+              x={CX + R * k + 5}
+              y={CY - 5}
+              fontFamily="var(--font-mono)"
+              fontSize="9"
+              fill="var(--ink-mute)"
+            >
+              {RING_LABELS[i]}
+            </text>
+          </g>
+        ))}
+
+        {/* Sector divider lines */}
+        {selectedCats.map((_, i) => {
+          const sector = (Math.PI * 2) / selectedCats.length;
+          const a0 = -Math.PI / 2 + i * sector;
+          return (
+            <line
+              key={i}
+              x1={CX}
+              y1={CY}
+              x2={CX + Math.cos(a0) * R}
+              y2={CY + Math.sin(a0) * R}
+              stroke="var(--rule-soft)"
+              strokeWidth="1"
+            />
+          );
+        })}
+
+        {/* Sector labels */}
+        {selectedCats.map((cat, i) => {
+          const sector = (Math.PI * 2) / selectedCats.length;
+          const am = -Math.PI / 2 + i * sector + sector / 2;
+          const lx = CX + Math.cos(am) * (R + 26);
+          const ly = CY + Math.sin(am) * (R + 26);
+          const cssSlug = catToCssSlug(cat);
+          const label = CATEGORY_LABELS[cat as CatSlug] ?? cat;
+          return (
+            <text
+              key={cat}
+              x={lx}
+              y={ly}
+              fontFamily="var(--font-sans)"
+              fontSize="11"
+              fontWeight="600"
+              textAnchor="middle"
+              fill={`var(--cat-${cssSlug})`}
+            >
+              {label}
+            </text>
+          );
+        })}
+
+        {/* Decorative sweep line at -32° */}
+        <line
+          x1={CX}
+          y1={CY}
+          x2={CX + R}
+          y2={CY}
+          stroke="var(--accent)"
+          strokeWidth="1.25"
+          strokeDasharray="2 5"
+          opacity="0.45"
+          transform={`rotate(-32 ${CX} ${CY})`}
+        />
+
+        {/* Center dot */}
+        <circle cx={CX} cy={CY} r={5} fill="var(--accent)" />
+        <circle
+          cx={CX}
+          cy={CY}
+          r={13}
+          fill="none"
+          stroke="var(--accent)"
+          strokeWidth="1"
+        />
+
+        {/* Bubbles */}
+        {placed.map(({ tech, x, y, size, isCategoryLeader, labelSide }) => {
+          const cssSlug = catToCssSlug(tech.category);
+          const catColor = `var(--cat-${cssSlug}, var(--accent))`;
+          const bubbleFill = isCategoryLeader
+            ? catColor
+            : `color-mix(in oklab, ${catColor} 35%, var(--surface))`;
+          const catLabel = CATEGORY_LABELS[tech.category as CatSlug] ?? tech.category;
+          const ariaLabel = `${tech.name} — ${tech.count} roles, ${catLabel}`;
+          const isFocused = focusedBubble === tech.name;
+
+          return (
+            <g
+              key={tech.name}
+              role="button"
+              tabIndex={0}
+              aria-label={ariaLabel}
+              style={{ cursor: "pointer", outline: "none" }}
+              onClick={() => navigate(tech.name)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  navigate(tech.name);
+                }
+              }}
+              onMouseEnter={() => showTooltip(tech, x, y)}
+              onMouseLeave={hideTooltip}
+              onFocus={() => {
+                setFocusedBubble(tech.name);
+                showTooltip(tech, x, y);
+              }}
+              onBlur={() => {
+                setFocusedBubble(null);
+                hideTooltip();
+              }}
+            >
+              {/* Expanded hit target so small bubbles are easier to click/tap */}
+              <circle
+                cx={x}
+                cy={y}
+                r={Math.max(size + 6, 18)}
+                fill="transparent"
+                aria-hidden
+              />
+              {/* Visible focus ring — accent circle shown when keyboard-focused */}
+              {isFocused && (
+                <circle
+                  cx={x}
+                  cy={y}
+                  r={size + 4}
+                  fill="none"
+                  stroke="var(--accent)"
+                  strokeWidth="2"
+                  aria-hidden
+                />
+              )}
+              <circle
+                cx={x}
+                cy={y}
+                r={size}
+                fill={bubbleFill}
+                stroke="var(--rule-soft)"
+                strokeWidth="1"
+              />
+              {/* Inline label for category leaders */}
+              {isCategoryLeader && (
+                <>
+                  <text
+                    x={labelSide === "right" ? x + size + 4 : x - size - 4}
+                    y={y + 3}
+                    fontFamily="var(--font-sans)"
+                    fontSize="10.5"
+                    fontWeight="600"
+                    textAnchor={labelSide === "right" ? "start" : "end"}
+                    fill="var(--ink)"
+                    aria-hidden
+                  >
+                    {tech.name}
+                  </text>
+                  <text
+                    x={labelSide === "right" ? x + size + 4 : x - size - 4}
+                    y={y + 14}
+                    fontFamily="var(--font-mono)"
+                    fontSize="8.5"
+                    textAnchor={labelSide === "right" ? "start" : "end"}
+                    fill="var(--ink-mute)"
+                    aria-hidden
+                  >
+                    {tech.count}
+                  </text>
+                </>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Legend */}
+        <text
+          x="16"
+          y="470"
+          fontFamily="var(--font-mono)"
+          fontSize="9"
+          fill="var(--ink-mute)"
+        >
+          ◯ size = job count · proximity to center = rank · click to filter
+        </text>
+      </svg>
+
+      {/* HTML tooltip overlay — positioned in % coords over the SVG viewBox.
+          Fully inline styles so the tooltip works regardless of CSS build order. */}
+      {tooltip && (
+        <div
+          role="tooltip"
+          style={{
+            position: "absolute",
+            left: `${((tooltip.vx / 560) * 100).toFixed(1)}%`,
+            top: `${((tooltip.vy / 480) * 100).toFixed(1)}%`,
+            transform: tooltipTransform,
+            pointerEvents: "none",
+            zIndex: 20,
+            background: "var(--surface)",
+            border: "1px solid var(--rule-soft)",
+            borderRadius: 6,
+            padding: "4px 8px",
+            whiteSpace: "nowrap",
+            boxShadow: "0 2px 8px rgba(0,0,0,0.10)",
+          }}
+        >
+          <span
+            style={{
+              display: "block",
+              fontFamily: "var(--font-sans)",
+              fontSize: 12,
+              fontWeight: 600,
+              color: "var(--ink)",
+              lineHeight: 1.4,
+            }}
+          >
+            {tooltip.name}
+          </span>
+          <span
+            style={{
+              display: "block",
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              color: "var(--ink-mute)",
+              fontVariantNumeric: "tabular-nums",
+              lineHeight: 1.4,
+            }}
+          >
+            {tooltip.count} roles · {tooltip.category}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Replaces native SVG `<title>` browser tooltips on unlabeled radar bubbles with a styled, mobile-friendly HTML overlay
- Extracts `RadarChart` from `trends/page.tsx` into a new `RadarChartClient` (`"use client"`) component to support hover/focus state
- Every bubble gets `role="button"`, `tabIndex={0}`, and `aria-label="Name — N roles, Category"`

## Tooltip approach: React client component (Option B)

SVG elements don't support CSS `::after` pseudo-elements reliably across browsers, ruling out Option A. The tooltip is a positioned `<div>` overlaid on the SVG using percentage coordinates derived from the SVG viewBox (`vx/560 * 100%`, `vy/480 * 100%`). Styles are inline rather than CSS classes — Turbopack in dev mode did not pick up new `globals.css` classes added mid-session; inline styles are also more portable and co-located with the component.

## Accessibility verification

- `role="button"` + `tabIndex={0}` on every bubble `<g>`
- `aria-label`: `"Python — 86 roles, Languages"` format
- Keyboard `Enter` and `Space` both navigate to `/?tech=<name>`
- Visible focus ring: accent-colored SVG `<circle>` drawn on keyboard focus
- Tooltip appears on both `onMouseEnter` and `onFocus`; dismissed on `onMouseLeave` / `onBlur`
- SVG retains top-level `<title>` + `<desc>` for screen readers
- Category leader inline labels (`aria-hidden`) preserved unchanged

## Manual desktop / mobile checks

- Unlabeled bubbles show styled tooltip card (white bg, border, `6px` radius) on hover
- Tooltip content: `TypeScript` / `42 roles · Languages`
- Inline category leader labels (Python, React, Kafka, Kubernetes…) still render in SVG
- Clicking a bubble navigates to `/?tech=<name>` ✅
- Enter / Space on focused bubble navigate correctly ✅
- 31 focusable bubbles confirmed in Playwright at 1440px and 375px
- No horizontal overflow at 375px (`scrollWidth = viewportWidth`)
- Expanded transparent hit target on each bubble for easier touch interaction
- Mobile tap navigates directly (tooltip appears momentarily on press; no two-tap trap)

## Files changed

- `frontend/components/RadarChartClient.tsx` — new client component (extracted + extended)
- `frontend/app/trends/page.tsx` — removes inline `RadarChart`, imports `RadarChartClient`
- `frontend/app/globals.css` — trailing newline only (tooltip CSS moved inline)

Closes #29