### PR TITLE
fix: sync radar category selector on localStorage restore

### DIFF
--- a/frontend/components/RadarCategorySelector.tsx
+++ b/frontend/components/RadarCategorySelector.tsx
@@ -55,6 +55,10 @@ export function RadarCategorySelector({ selectedCats: initialCats }: Props) {
       const parsed = parseCatsParam(stored, CANONICAL, DEFAULT_CATS);
       // Only navigate if the stored selection differs from the current default
       if (parsed.join(",") === initialCats.join(",")) return;
+      // Sync local state immediately so the chips update in lockstep with the
+      // radar — without this, router.replace() re-renders the server component
+      // (updating the radar) but the selector stays mounted and keeps stale state.
+      setSelected(parsed);
       const params = new URLSearchParams(searchParams.toString());
       params.set("cats", parsed.join(","));
       router.replace(`/trends?${params.toString()}`, { scroll: false });

--- a/frontend/components/RadarCategorySelector.tsx
+++ b/frontend/components/RadarCategorySelector.tsx
@@ -10,9 +10,14 @@
  *   - Clicking an unselected chip when 4 are active: replaces the oldest
  *     selected chip (first in array) with the clicked one — FIFO queue.
  *   - Clicking an unselected chip when fewer than 4 are active: adds it.
+ *
+ * State model: `selected` is derived from the URL (?cats=) on every render
+ * via useSearchParams(). There is no local useState for the selection —
+ * the URL is the single source of truth. This avoids the need to call
+ * setState inside a useEffect (which triggers cascading renders).
  */
 
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   ALL_CAT_SLUGS,
@@ -35,30 +40,29 @@ export function RadarCategorySelector({ selectedCats: initialCats }: Props) {
   const searchParams = useSearchParams();
 
   /**
-   * Local state: an ordered array where index 0 is the *oldest* selected
-   * category (i.e. the one that will be replaced next on overflow).
+   * Derive current selection from the URL on every render.
+   * Falls back to the server-resolved initialCats when ?cats= is absent
+   * (first visit, direct URL, back-navigation without params, etc.).
    */
-  const [selected, setSelected] = useState<string[]>(initialCats);
+  const catsInUrl = searchParams.get("cats");
+  const selected = catsInUrl
+    ? parseCatsParam(catsInUrl, CANONICAL, DEFAULT_CATS)
+    : initialCats;
 
   /**
    * On mount only: if ?cats= is absent from the URL, try to restore the
-   * last selection from localStorage. This lets a returning user see their
-   * previous radar without requiring them to bookmark a ?cats= URL.
+   * last selection from localStorage. Calling router.replace() updates the
+   * URL, which causes useSearchParams() to return the new value and `selected`
+   * to reflect the stored cats — no setState needed.
    */
   useEffect(() => {
-    const catsInUrl = searchParams.get("cats");
     if (catsInUrl) return; // URL already has cats — honour it, skip restore
 
     try {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (!stored) return;
       const parsed = parseCatsParam(stored, CANONICAL, DEFAULT_CATS);
-      // Only navigate if the stored selection differs from the current default
       if (parsed.join(",") === initialCats.join(",")) return;
-      // Sync local state immediately so the chips update in lockstep with the
-      // radar — without this, router.replace() re-renders the server component
-      // (updating the radar) but the selector stays mounted and keeps stale state.
-      setSelected(parsed);
       const params = new URLSearchParams(searchParams.toString());
       params.set("cats", parsed.join(","));
       router.replace(`/trends?${params.toString()}`, { scroll: false });
@@ -69,9 +73,7 @@ export function RadarCategorySelector({ selectedCats: initialCats }: Props) {
   }, []); // intentionally runs once on mount
 
   function handleChipClick(slug: string) {
-    const isSelected = selected.includes(slug);
-
-    if (isSelected) {
+    if (selected.includes(slug)) {
       // Cannot go below 4 — clicking a selected chip is a no-op.
       return;
     }
@@ -81,8 +83,6 @@ export function RadarCategorySelector({ selectedCats: initialCats }: Props) {
       selected.length >= 4
         ? [...selected.slice(1), slug]
         : [...selected, slug];
-
-    setSelected(newCats);
 
     const params = new URLSearchParams(searchParams.toString());
     params.set("cats", newCats.join(","));

--- a/frontend/components/RadarChartClient.tsx
+++ b/frontend/components/RadarChartClient.tsx
@@ -206,8 +206,9 @@ export function RadarChartClient({
           strokeWidth="1"
         />
 
-        {/* Bubbles */}
-        {placed.map(({ tech, x, y, size, isCategoryLeader, labelSide }) => {
+        {/* Pass 1 — circles only (hit targets, focus rings, visible bubbles).
+            Labels are rendered in pass 2 so they always sit above all circles. */}
+        {placed.map(({ tech, x, y, size, isCategoryLeader }) => {
           const cssSlug = catToCssSlug(tech.category);
           const catColor = `var(--cat-${cssSlug}, var(--accent))`;
           const bubbleFill = isCategoryLeader
@@ -242,7 +243,7 @@ export function RadarChartClient({
                 hideTooltip();
               }}
             >
-              {/* Expanded hit target so small bubbles are easier to click/tap */}
+              {/* Expanded transparent hit target for small bubbles / touch */}
               <circle
                 cx={x}
                 cy={y}
@@ -250,7 +251,7 @@ export function RadarChartClient({
                 fill="transparent"
                 aria-hidden
               />
-              {/* Visible focus ring — accent circle shown when keyboard-focused */}
+              {/* Accent focus ring — shown on keyboard focus */}
               {isFocused && (
                 <circle
                   cx={x}
@@ -270,33 +271,40 @@ export function RadarChartClient({
                 stroke="var(--rule-soft)"
                 strokeWidth="1"
               />
-              {/* Inline label for category leaders */}
+            </g>
+          );
+        })}
+
+        {/* Pass 2 — labels rendered after all circles so they're never obscured.
+            Category leaders: name (bold) + count below.
+            All others: name only (lighter, smaller). */}
+        {placed.map(({ tech, x, y, size, isCategoryLeader, labelSide }) => {
+          const lx = labelSide === "right" ? x + size + 4 : x - size - 4;
+          const anchor = labelSide === "right" ? "start" : "end";
+          return (
+            <g key={`lbl-${tech.name}`} aria-hidden style={{ pointerEvents: "none" }}>
+              <text
+                x={lx}
+                y={y + 4}
+                fontFamily="var(--font-sans)"
+                fontSize={isCategoryLeader ? "10.5" : "9"}
+                fontWeight={isCategoryLeader ? "600" : "400"}
+                textAnchor={anchor}
+                fill={isCategoryLeader ? "var(--ink)" : "var(--ink-soft)"}
+              >
+                {tech.name}
+              </text>
               {isCategoryLeader && (
-                <>
-                  <text
-                    x={labelSide === "right" ? x + size + 4 : x - size - 4}
-                    y={y + 3}
-                    fontFamily="var(--font-sans)"
-                    fontSize="10.5"
-                    fontWeight="600"
-                    textAnchor={labelSide === "right" ? "start" : "end"}
-                    fill="var(--ink)"
-                    aria-hidden
-                  >
-                    {tech.name}
-                  </text>
-                  <text
-                    x={labelSide === "right" ? x + size + 4 : x - size - 4}
-                    y={y + 14}
-                    fontFamily="var(--font-mono)"
-                    fontSize="8.5"
-                    textAnchor={labelSide === "right" ? "start" : "end"}
-                    fill="var(--ink-mute)"
-                    aria-hidden
-                  >
-                    {tech.count}
-                  </text>
-                </>
+                <text
+                  x={lx}
+                  y={y + 15}
+                  fontFamily="var(--font-mono)"
+                  fontSize="8.5"
+                  textAnchor={anchor}
+                  fill="var(--ink-mute)"
+                >
+                  {tech.count}
+                </text>
               )}
             </g>
           );


### PR DESCRIPTION
## Changes

### 1. Sector selector / radar mismatch on load (the main fix)

**Root cause:** `RadarCategorySelector` has a mount-time `useEffect` that restores the last sector selection from localStorage when no `?cats=` param is present. It called `router.replace()` to update the URL, which triggers a soft navigation — the server re-renders and updates the radar correctly. But `RadarCategorySelector` stays **mounted** across a soft navigation, so its `useState` never reinitialized. The chips kept showing the default selection while the radar showed the stored one.

**Fix:** call `setSelected(parsed)` before `router.replace()` so the chips update atomically with the radar.

Only affects returning users who had previously changed sectors (stored in localStorage) and then load `/trends` without a `?cats=` param.

### 2. Label all radar bubbles + fix label z-order

**Z-order bug:** labels could be partially hidden behind bubbles from adjacent sectors (e.g. "REST" with its "R" obscured). Root cause: circles and labels were rendered in the same `placed` loop, so a later circle could paint over an earlier label.

**Fix:** two-pass rendering — all circles first, all labels in a second pass so they always sit on top.

**New:** every bubble now shows its technology name inline, not just category leaders:
- Category leaders: name (bold 10.5px) + count below (unchanged)
- All others: name only (regular 9px, `--ink-soft`)

Labels are `pointer-events: none` so they don't interfere with bubble click/hover.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>