### PR TITLE
feat: link role segments to preset radar sectors + rename data slug

### DIFF
--- a/frontend/app/api/radar/route.ts
+++ b/frontend/app/api/radar/route.ts
@@ -7,7 +7,7 @@
  * ────────────────
  * format   (optional) "json" | "svg"        — default: "json"
  * cats     (optional) comma-separated canonical category slugs
- *                     — default: "languages,frontend,devops,data_ai"
+ *                     — default: "languages,frontend,devops,data"
  * window   (optional) "7d" | "30d" | "90d" | "all"  — default: "30d"
  * segment  (optional) role segment slug to filter jobs before aggregation
  *                     — one of: startup_saas, enterprise, ai_ml,
@@ -17,9 +17,9 @@
  *
  * Examples
  * ────────
- * /api/radar?format=json&cats=languages,frontend,devops,data_ai
+ * /api/radar?format=json&cats=languages,frontend,devops,data
  * /api/radar?format=svg&cats=languages,backend,testing,mobile
- * /api/radar?format=json&segment=ai_ml&cats=languages,backend,data_ai,cloud
+ * /api/radar?format=json&segment=ai_ml&cats=languages,backend,data,cloud
  * /api/radar?format=svg&segment=mobile
  * /api/radar?format=json&segment=cloud_platform&window=90d
  *

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -27,14 +27,14 @@
   --wk-bg: #fce4d3;  --wk-fg: #d96b3a;   /* Workable */
 
   /* Category tokens — radar sector colors (one per canonical slug)      */
-  /* Slug → CSS name: replace _ with - e.g. data_ai → --cat-data-ai     */
+  /* Slug → CSS name: replace _ with - e.g. ai_concepts → --cat-ai-concepts */
   --cat-languages:   oklch(0.55 0.18 252);  /* blue    — same as --accent */
   --cat-frontend:    oklch(0.55 0.18 160);  /* teal                       */
   --cat-backend:     oklch(0.55 0.18 200);  /* cyan                       */
   --cat-databases:   oklch(0.55 0.18 295);  /* violet                     */
   --cat-cloud:       oklch(0.55 0.18 55);   /* amber                      */
   --cat-devops:      oklch(0.55 0.18 30);   /* orange                     */
-  --cat-data-ai:     oklch(0.55 0.18 20);   /* coral                      */
+  --cat-data:        oklch(0.55 0.18 20);   /* coral                      */
   --cat-mobile:      oklch(0.55 0.18 330);  /* rose                       */
   --cat-testing:     oklch(0.55 0.18 130);  /* green                      */
   --cat-ai-concepts: oklch(0.55 0.18 85);   /* lime                       */

--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -155,7 +155,6 @@ export default async function TrendsPage({
         >
           <SegmentFilter
             activeSegment={activeSegment}
-            selectedCats={selectedCats}
             activeWindow={activeWindow}
           />
         </div>

--- a/frontend/components/RadarDownloadPanel.tsx
+++ b/frontend/components/RadarDownloadPanel.tsx
@@ -12,7 +12,7 @@
 
 import { useState, useSyncExternalStore } from "react";
 
-const BASE_URL = "https://jobs-radar-qc.dev";
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://jobs-radar-qc.vercel.app";
 const BG_STORAGE_KEY = "jobs-radar-qc:radar-bg";
 
 type BgPref = "light" | "dark" | null;

--- a/frontend/components/SegmentFilter.tsx
+++ b/frontend/components/SegmentFilter.tsx
@@ -10,28 +10,30 @@
  *
  * Props:
  *   activeSegment  — currently active slug, or null for "All"
- *   selectedCats   — current ?cats= value (preserved in generated hrefs)
  *   activeWindow   — current ?window= value (preserved in generated hrefs)
  */
 
 import Link from "next/link";
 import { ALL_SEGMENT_SLUGS, SEGMENT_LABELS } from "@/lib/segmentHelpers";
+import { DEFAULT_CATS, SEGMENT_DEFAULT_CATS } from "@/lib/radarHelpers";
 import type { WindowOption } from "@/lib/radarData";
 
 interface Props {
   activeSegment: string | null;
-  selectedCats: string[];
   activeWindow: WindowOption;
 }
 
-export function SegmentFilter({ activeSegment, selectedCats, activeWindow }: Props) {
+export function SegmentFilter({ activeSegment, activeWindow }: Props) {
   /**
-   * Build a href that sets ?segment=<slug> while preserving ?cats= and ?window=.
-   * Passing null produces the "All" href (no ?segment= param).
+   * Build a href that sets ?segment=<slug> and ?cats= to the segment's preset
+   * sectors. "All" (null) resets to global defaults.
    */
   function href(slug: string | null): string {
+    const cats = slug
+      ? [...(SEGMENT_DEFAULT_CATS[slug] ?? DEFAULT_CATS)]
+      : [...DEFAULT_CATS];
     const params = new URLSearchParams();
-    params.set("cats", selectedCats.join(","));
+    params.set("cats", cats.join(","));
     params.set("window", activeWindow);
     if (slug) params.set("segment", slug);
     return `/trends?${params.toString()}`;
@@ -109,7 +111,7 @@ export function SegmentFilter({ activeSegment, selectedCats, activeWindow }: Pro
           fontSize: 9,
         }}
       >
-        Filter radar to one market segment
+        Sectors adapt to the selected segment
       </p>
     </div>
   );

--- a/frontend/lib/radarHelpers.ts
+++ b/frontend/lib/radarHelpers.ts
@@ -28,7 +28,7 @@ export const ALL_CAT_SLUGS = [
   "databases",
   "cloud",
   "devops",
-  "data_ai",
+  "data",
   "mobile",
   "testing",
   "ai_concepts",
@@ -44,7 +44,7 @@ export const CATEGORY_LABELS: Record<CatSlug, string> = {
   databases:   "Databases",
   cloud:       "Cloud",
   devops:      "DevOps",
-  data_ai:     "Data / AI",
+  data:        "Data",
   mobile:      "Mobile",
   testing:     "Testing",
   ai_concepts: "AI Concepts",
@@ -52,7 +52,7 @@ export const CATEGORY_LABELS: Record<CatSlug, string> = {
 
 /**
  * CSS slug — convert underscore-separated slug to hyphen for CSS custom
- * property names. Example: "data_ai" → "data-ai", "ai_concepts" → "ai-concepts".
+ * property names. Example: "ai_concepts" → "ai-concepts".
  */
 export function catToCssSlug(slug: string): string {
   return slug.replace(/_/g, "-");
@@ -63,8 +63,19 @@ export const DEFAULT_CATS: readonly string[] = [
   "languages",
   "frontend",
   "devops",
-  "data_ai",
+  "data",
 ];
+
+/** Pre-set radar sectors for each role segment, derived from segment classification rules. */
+export const SEGMENT_DEFAULT_CATS: Record<string, readonly [CatSlug, CatSlug, CatSlug, CatSlug]> = {
+  startup_saas:   ["frontend",  "backend",    "databases",  "languages"],
+  enterprise:     ["languages", "backend",    "databases",  "cloud"],
+  ai_ml:          ["data",      "ai_concepts","languages",  "cloud"],
+  cloud_platform: ["cloud",     "devops",     "backend",    "databases"],
+  consulting:     ["languages", "backend",    "frontend",   "databases"],
+  fintech:        ["languages", "backend",    "databases",  "devops"],
+  mobile:         ["mobile",    "languages",  "frontend",   "backend"],
+};
 
 /**
  * Inline canonical data — mirrors core/canonical_tech_stack.json v2.
@@ -97,7 +108,7 @@ export const CANONICAL: CanonicalStack = {
       "GitHub Actions", "Jenkins", "ArgoCD",
       "Prometheus", "Grafana", "Ansible",
     ],
-    data_ai: [
+    data: [
       "Pandas", "Spark", "Databricks", "Airflow",
       "TensorFlow", "PyTorch", "LangChain", "OpenAI",
       "Vector DB", "dbt", "Kafka", "MLflow",
@@ -230,7 +241,7 @@ export const CAT_COLORS: Record<string, string> = {
   databases:   "#7949cc",  // oklch(0.55 0.18 295) — violet
   cloud:       "#b89020",  // oklch(0.55 0.18  55) — amber
   devops:      "#cc6620",  // oklch(0.55 0.18  30) — orange
-  data_ai:     "#cc5245",  // oklch(0.55 0.18  20) — coral
+  data:        "#cc5245",  // oklch(0.55 0.18  20) — coral
   mobile:      "#cc3d70",  // oklch(0.55 0.18 330) — rose
   testing:     "#38a847",  // oklch(0.55 0.18 130) — green
   ai_concepts: "#849920",  // oklch(0.55 0.18  85) — lime


### PR DESCRIPTION
## Summary

- **Segment → sector linking**: clicking a role segment pill now automatically sets the 4 radar sectors to the most relevant categories for that segment (e.g. AI/ML → Data, AI Concepts, Languages, Cloud). Clicking "All" resets to global defaults. Previously the sectors were preserved from whatever the user last had selected.
- **`data_ai` slug renamed to `data`**: the internal slug (used in URLs, CSS vars, and the canonical tech map) is now `data` to match the display label "Data". Affected: `ALL_CAT_SLUGS`, `CATEGORY_LABELS`, `DEFAULT_CATS`, `SEGMENT_DEFAULT_CATS`, `CANONICAL`, SVG color palette, `--cat-data-ai` → `--cat-data`, and API doc comments.
- **Download panel domain fix**: `BASE_URL` was hardcoded to `jobs-radar-qc.dev`; now reads `NEXT_PUBLIC_SITE_URL` with fallback to `jobs-radar-qc.vercel.app`.

## Segment → sector mapping

| Segment | Preset sectors |
|---|---|
| Startup SaaS | frontend, backend, databases, languages |
| Enterprise | languages, backend, databases, cloud |
| AI/ML | data, ai_concepts, languages, cloud |
| Cloud/Platform | cloud, devops, backend, databases |
| Consulting | languages, backend, frontend, databases |
| FinTech | languages, backend, databases, devops |
| Mobile | mobile, languages, frontend, backend |

## Test plan

- [ ] Open `/trends` — default sectors are `languages, frontend, devops, data` (chip labeled "Data", not "Data / AI")
- [ ] Click each segment pill — confirm sector chips update to the preset for that segment
- [ ] Click "All" — confirm sectors reset to global defaults
- [ ] Check URL after clicking AI/ML: `?cats=data,ai_concepts,languages,cloud&segment=ai_ml`
- [ ] Download SVG — curl command in panel shows `jobs-radar-qc.vercel.app`, not `jobs-radar-qc.dev`
- [ ] Hint text under segment pills reads "Sectors adapt to the selected segment"

🤖 Generated with [Claude Code](https://claude.com/claude-code)