### PR TITLE
fix: pin nav to viewport width regardless of horizontal page overflow

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -60,10 +60,10 @@ export default function RootLayout({
         * behind the fixed BottomTabBar on mobile.
         * lg:pb-0 removes that padding on desktop where the bar is hidden.
         */}
-      <body className="flex min-h-full flex-col pb-14 lg:pb-0" style={{ background: "var(--bg)", color: "var(--ink)" }}>
+      <body className="flex min-h-full flex-col pb-14 pt-11.25 lg:pb-0" style={{ background: "var(--bg)", color: "var(--ink)" }}>
         {/* Top navigation */}
         <header
-          className="sticky top-0 z-40 border-b"
+          className="fixed inset-x-0 top-0 z-40 border-b"
           style={{ background: "var(--surface)", borderColor: "var(--rule-soft)" }}
         >
           <nav className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">


### PR DESCRIPTION
## Summary

- Changes the top `<header>` from `position: sticky` to `position: fixed` (`fixed inset-x-0 top-0`)
- Adds `pt-11.25` (45 px) to `<body>` to compensate for the space the fixed header no longer holds in the document flow

## Why

`sticky` headers inherit the **document** scroll width. When any element on the page is wider than the viewport (intentional horizontal scroll on chip rows, filter bars, etc.), the document is wider than the viewport, so the sticky nav stretches past the screen edge — the search button gets clipped.

`fixed` elements always size to the **viewport**, so the nav stays correctly pinned regardless of how wide the page content is.

Verified at 390 px: `navWidth = 390`, `docWidth = 415` — nav is exactly viewport-wide even though the page overflows by 25 px.

## Test plan

- [ ] Open `/` on mobile — nav is full viewport width, search button not clipped
- [ ] Scroll content horizontally — nav stays fixed and viewport-wide
- [ ] Open `/trends` on mobile — same behaviour
- [ ] Desktop — no visual regression, all nav links visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)