### PR TITLE
fix: prepend site prefix to Workday job URLs (were 404)

### DIFF
--- a/pipeline/extractor.py
+++ b/pipeline/extractor.py
@@ -385,6 +385,12 @@ class Extractor:
         # api_url ends with "/jobs"; strip that suffix to get the CXS api base.
         api_base = api_url.removesuffix("/jobs")
         base_url = company.get("base_url", "").rstrip("/")
+        # The site name is the last path segment of the CXS api base
+        # (e.g. "Desjardins" from ".../cxs/desjardins/Desjardins").
+        # Workday's CXS API returns externalPath WITHOUT the site prefix
+        # (e.g. "/job/Montreal/..." instead of "/Desjardins/job/Montreal/..."),
+        # but the public career portal URL requires it.
+        site = api_base.rstrip("/").rsplit("/", 1)[-1]
         for raw_job in raw_jobs:
             ext_path = raw_job.get("externalPath", "")
             raw_job["_api_base"] = api_base
@@ -393,7 +399,11 @@ class Extractor:
                 ext_path.rstrip("/").rsplit("/", 1)[-1] if ext_path else None
             )
             if base_url and ext_path:
-                raw_job["_source_url"] = base_url + ext_path
+                # Add site prefix if the API omitted it (the common case).
+                public_path = (
+                    ext_path if ext_path.startswith(f"/{site}") else f"/{site}{ext_path}"
+                )
+                raw_job["_source_url"] = base_url + public_path
 
         await self._fetch_workday_descriptions(client, raw_jobs)
 

--- a/specs/workday/source.md
+++ b/specs/workday/source.md
@@ -80,7 +80,10 @@ two URL fields instead of a simple slug:
 | `api_url`  | Full CXS `/jobs` endpoint URL (POST target)                    |
 | `base_url` | Tenant domain root — used to construct human-facing source_url |
 
-The human-facing `source_url` is: `base_url + externalPath`  
+The human-facing `source_url` is: `base_url + /{site} + externalPath`  
+The Workday CXS API returns `externalPath` **without** the site prefix
+(e.g. `/job/Montreal/Engineer_JR-001`), but the public career portal URL requires it.
+The extractor prepends `/{site}` when it is absent.  
 (e.g., `https://example.wd3.myworkdayjobs.com/ExampleCareers/job/Montreal/Engineer_JR-001`)
 
 ---
@@ -117,7 +120,7 @@ company's actual careers page URL — the CXS API path is identical across versi
   "jobPostings": [
     {
       "title": "Cloud Engineer",
-      "externalPath": "/BellCareers/job/Montreal-Quebec/Cloud-Engineer_JR-2000",
+      "externalPath": "/job/Montreal-Quebec/Cloud-Engineer_JR-2000",
       "locationsText": "Montréal, Quebec, Canada",
       "postedOn": "Posted 3 Days Ago",
       "jobReqId": "JR-2000",


### PR DESCRIPTION
## Root cause

The Workday CXS API returns `externalPath` **without** the site name prefix:
```
externalPath = "/job/Montreal/Cloud-Engineer_JR-2000"   ← actual API response
```
But the public career portal URL requires it:
```
https://tenant.wd3.myworkdayjobs.com/SiteName/job/Montreal/Cloud-Engineer_JR-2000
                                      ^^^^^^^^ missing
```

The extractor was doing `base_url + externalPath` directly, producing broken 404 URLs. Confirmed against all 3 tested tenants (Desjardins, Intact, CAE, Cogeco).

## Fix

Extract `site` from the last segment of the CXS `api_base` and prepend it to `externalPath` when absent. This is symmetric to what `_fetch_workday_descriptions` already does in reverse (strips the site prefix for the internal API URL).

```python
site = api_base.rstrip("/").rsplit("/", 1)[-1]   # e.g. "Desjardins"
public_path = ext_path if ext_path.startswith(f"/{site}") else f"/{site}{ext_path}"
raw_job["_source_url"] = base_url + public_path
```

**Verified:**
```
broken: https://desjardins.wd10.myworkdayjobs.com/job/Montral/...  → 404
fixed:  https://desjardins.wd10.myworkdayjobs.com/Desjardins/job/Montral/... → 200
```

Also fixes the misleading `externalPath` example in `specs/workday/source.md` which incorrectly showed the site prefix as part of the API response.

## Test plan

- [ ] 277 existing tests pass (`pytest tests/ -x -q`)
- [ ] After next pipeline run, Workday job links resolve to 200 (not 404)
- [ ] All 8 Workday companies affected: Desjardins, Intact, CAE, McGill, Cogeco, AtkinsRéalis, Saputo, PSP Investments

🤖 Generated with [Claude Code](https://claude.com/claude-code)