### PR TITLE
feat(radar): SegmentFilter full-width above the chart

### DIFF
--- a/frontend/app/trends/page.tsx
+++ b/frontend/app/trends/page.tsx
@@ -63,7 +63,17 @@ export default async function TrendsPage({
   const focusCoMentions = focusTech ? (coMentions[focusTech.name] ?? []) : [];
 
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col px-4 py-6 lg:flex-row lg:gap-0">
+    <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col px-4 py-6">
+      {/* ── Segment filter — full width above the radar ──────────────── */}
+      <div
+        className="mb-4 pb-3"
+        style={{ borderBottom: "1px solid var(--rule-soft)" }}
+      >
+        <SegmentFilter activeSegment={activeSegment} activeWindow={activeWindow} />
+      </div>
+
+      {/* ── Main content row ─────────────────────────────────────────── */}
+      <div className="flex flex-1 flex-col lg:flex-row lg:gap-0">
       {/* ── Main radar area ─────────────────────────────────────────── */}
       <div className="flex flex-1 flex-col">
         {/* Page header */}
@@ -148,17 +158,6 @@ export default async function TrendsPage({
         className="mt-4 flex flex-col gap-4 lg:ml-5 lg:mt-0 lg:w-72"
         style={{ flexShrink: 0 }}
       >
-        {/* Segment filter — Server Component (Link pills) */}
-        <div
-          className="rounded-md p-3"
-          style={{ background: "var(--bg-2)", border: "1px solid var(--rule-soft)" }}
-        >
-          <SegmentFilter
-            activeSegment={activeSegment}
-            activeWindow={activeWindow}
-          />
-        </div>
-
         {/* Radar sector selector — Client Component */}
         <div
           className="rounded-md p-3"
@@ -303,6 +302,7 @@ export default async function TrendsPage({
         {/* Embed / API card — dynamic curl commands */}
         <RadarDownloadPanel cats={selectedCats} segment={activeSegment} />
       </div>
+      </div>{/* ── end main content row ── */}
     </div>
   );
 }

--- a/frontend/components/SegmentFilter.tsx
+++ b/frontend/components/SegmentFilter.tsx
@@ -45,23 +45,25 @@ export function SegmentFilter({ activeSegment, activeWindow }: Props) {
   ];
 
   return (
-    <div>
-      {/* Section header */}
-      <div className="mb-2">
-        <span
-          className="text-xs font-semibold uppercase tracking-widest"
-          style={{
-            color: "var(--ink-mute)",
-            fontFamily: "var(--font-mono)",
-            fontSize: 9,
-          }}
-        >
-          Role segment
-        </span>
-      </div>
+    <div className="flex min-w-0 items-center gap-3">
+      {/* Label — visible on sm+, hidden on smallest mobile */}
+      <span
+        className="hidden shrink-0 text-xs font-semibold uppercase tracking-widest sm:block"
+        style={{
+          color: "var(--ink-mute)",
+          fontFamily: "var(--font-mono)",
+          fontSize: 9,
+        }}
+      >
+        Segment
+      </span>
 
-      {/* Pill row */}
-      <nav aria-label="Filter by role segment" className="flex flex-wrap gap-1.5">
+      {/* Pill row — no wrap, horizontal scroll on mobile */}
+      <nav
+        aria-label="Filter by role segment"
+        className="flex min-w-0 gap-1.5 overflow-x-auto pb-0.5"
+        style={{ scrollbarWidth: "none" }}
+      >
         {allItems.map(({ slug, label }) => {
           const isActive = slug === activeSegment;
           return (
@@ -71,6 +73,7 @@ export function SegmentFilter({ activeSegment, activeWindow }: Props) {
               scroll={false}
               aria-current={isActive ? "page" : undefined}
               style={{
+                flexShrink: 0,
                 display: "inline-flex",
                 alignItems: "center",
                 minHeight: 28,
@@ -88,31 +91,14 @@ export function SegmentFilter({ activeSegment, activeWindow }: Props) {
                 transition:
                   "background 120ms ease-out, border-color 120ms ease-out, color 120ms ease-out",
                 cursor: "pointer",
-                /* Ensure keyboard focus ring is visible — ring applied via
-                   focus-visible in globals.css; outline:none suppresses native ring
-                   in favour of the custom one. */
                 outline: "none",
               }}
-              /* Inline focus-visible ring as inline style fallback */
-              onFocus={undefined}
             >
               {label}
             </Link>
           );
         })}
       </nav>
-
-      {/* Hint */}
-      <p
-        className="mt-1.5"
-        style={{
-          color: "var(--ink-mute)",
-          fontFamily: "var(--font-mono)",
-          fontSize: 9,
-        }}
-      >
-        Sectors adapt to the selected segment
-      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Moves the segment pills (`All`, `Mobile`, `Fintech`, `AI/ML`, `Cloud & Platform`, `Consulting`, `Enterprise`, `Startup SaaS`) from the narrow side rail to a full-width bar above the radar chart and side rail
- On mobile the pills scroll horizontally — no longer hidden below the fold
- On desktop they sit in a single line next to an inline `Segment` label
- `RadarCategorySelector`, top techs, co-mentions, and download panel remain in the side rail unchanged
- The "Sectors adapt to the selected segment" hint was removed — it was only meaningful when both filters were adjacent in the side rail

## Files changed

| File | Change |
|---|---|
| `frontend/app/trends/page.tsx` | Outer wrapper stays `flex-col`; `SegmentFilter` injected above a new inner `flex-row` div |
| `frontend/components/SegmentFilter.tsx` | Inline label + `overflow-x-auto` no-wrap pill row; `flexShrink:0` on each pill |

## Checks

- `npm run lint` — 0 errors (1 pre-existing warning in unrelated file)
- `npm run build` — clean, `/trends` emits as dynamic route

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)