### PR TITLE
feat(extraction): add missing technologies and AI concepts to pipeline

### DIFF
--- a/core/canonical_tech_stack.json
+++ b/core/canonical_tech_stack.json
@@ -3,40 +3,50 @@
   "categories": {
     "languages": [
       "Python", "Java", "TypeScript", "JavaScript", "C#", "Go",
-      "SQL", "Kotlin", "Swift", "Rust"
+      "SQL", "Kotlin", "Swift", "Rust",
+      "Ruby", "PHP", "Scala", "Dart", "R", "Elixir", "C++"
     ],
     "frontend": [
-      "React", "Next.js", "Angular", "Vue", "Tailwind", "Redux", "Svelte"
+      "React", "Next.js", "Angular", "Vue", "Tailwind", "Redux", "Svelte",
+      "Vite", "tRPC", "Remix", "Storybook"
     ],
     "backend": [
       "Spring Boot", "Node.js", "Express", "NestJS", ".NET",
-      "Django", "FastAPI", "GraphQL", "REST", "gRPC"
+      "Django", "FastAPI", "GraphQL", "REST", "gRPC",
+      "Rails", "Laravel", "Flask", "ASP.NET", "Celery", "Gin"
     ],
     "databases": [
       "PostgreSQL", "MySQL", "MongoDB", "Redis",
-      "DynamoDB", "Snowflake", "Elasticsearch", "ClickHouse"
+      "DynamoDB", "Snowflake", "Elasticsearch", "ClickHouse",
+      "BigQuery", "Cassandra", "Firebase", "Supabase", "SQLite"
     ],
     "cloud": [
-      "AWS", "Azure", "GCP", "Linux", "Nginx", "Cloudflare"
+      "AWS", "Azure", "GCP", "Linux", "Nginx", "Cloudflare",
+      "Vercel", "DigitalOcean", "Heroku"
     ],
     "devops": [
       "Docker", "Kubernetes", "Terraform", "Helm",
       "GitHub Actions", "Jenkins", "ArgoCD",
-      "Prometheus", "Grafana", "Ansible"
+      "Prometheus", "Grafana", "Ansible",
+      "GitLab CI", "CircleCI", "Pulumi", "Vault"
     ],
     "data_ai": [
       "Pandas", "Spark", "Databricks", "Airflow",
       "TensorFlow", "PyTorch", "LangChain", "OpenAI",
-      "Vector DB", "dbt", "Kafka", "MLflow"
+      "Vector DB", "dbt", "Kafka", "MLflow",
+      "NumPy", "scikit-learn", "Hugging Face", "Flink", "RabbitMQ", "Weights & Biases"
     ],
     "mobile": [
       "React Native", "Flutter", "SwiftUI", "Android", "iOS"
     ],
     "testing": [
-      "Jest", "Cypress", "Playwright", "Selenium", "JUnit", "Postman"
+      "Jest", "Cypress", "Playwright", "Selenium", "JUnit", "Postman",
+      "Vitest", "pytest", "Mocha", "RSpec"
     ],
     "ai_concepts": [
-      "LLM", "RAG"
+      "LLM", "RAG",
+      "AI Agents", "Prompt Engineering", "Fine-tuning", "Embeddings",
+      "Semantic Search", "NLP", "Computer Vision", "GenAI"
     ]
   }
 }

--- a/specs/greenhouse/extraction.xml
+++ b/specs/greenhouse/extraction.xml
@@ -102,6 +102,7 @@
         <kw canonical="Ruby">Ruby</kw>
         <kw canonical="PHP">PHP</kw>
         <kw canonical="Swift">Swift</kw>
+        <kw canonical="Dart">Dart</kw>
         <kw canonical="Elixir">Elixir</kw>
         <kw canonical="Erlang">Erlang</kw>
         <kw canonical="R" case_sensitive="true">\bR\b</kw>
@@ -120,6 +121,11 @@
         <kw canonical="REST" case_sensitive="true">REST(?:ful)?</kw>
         <kw canonical="Tailwind">Tailwind(?:\s+CSS)?</kw>
         <kw canonical="Redux">Redux</kw>
+        <!-- Vite: case_sensitive avoids matching French "vite" (quickly) in bilingual postings -->
+        <kw canonical="Vite" case_sensitive="true">Vite</kw>
+        <kw canonical="tRPC" case_sensitive="true">tRPC</kw>
+        <kw canonical="Remix">Remix</kw>
+        <kw canonical="Storybook">Storybook</kw>
 
         <!-- Backend frameworks -->
         <kw canonical="Django">Django</kw>
@@ -131,48 +137,64 @@
         <kw canonical="Spring Boot">Spring(?:\s+Boot)?</kw>
         <kw canonical="NestJS">NestJS</kw>
         <kw canonical="gRPC">gRPC</kw>
+        <kw canonical="Celery">Celery</kw>
         <kw canonical="Laravel">Laravel</kw>
         <kw canonical="ASP.NET">ASP\.NET</kw>
         <kw canonical=".NET">\.NET</kw>
+        <!-- Gin: case_sensitive avoids matching the common English noun -->
+        <kw canonical="Gin" case_sensitive="true">Gin</kw>
 
         <!-- Data / ML / AI -->
         <kw canonical="Spark">(?:Apache )?Spark</kw>
         <kw canonical="Kafka">(?:Apache )?Kafka</kw>
         <kw canonical="Airflow">(?:Apache )?Airflow</kw>
+        <kw canonical="Flink">(?:Apache )?Flink</kw>
         <kw canonical="dbt">dbt</kw>
         <kw canonical="Pandas">Pandas</kw>
         <kw canonical="NumPy">NumPy</kw>
         <kw canonical="PyTorch">PyTorch</kw>
         <kw canonical="TensorFlow">TensorFlow</kw>
         <kw canonical="scikit-learn">scikit-learn</kw>
+        <kw canonical="Databricks">Databricks</kw>
+        <kw canonical="RabbitMQ">RabbitMQ</kw>
+        <!-- LLM/RAG: case_sensitive avoids "llm"/"rag" as lowercase abbreviations -->
         <kw canonical="LLM" case_sensitive="true">LLM</kw>
         <kw canonical="RAG" case_sensitive="true">RAG</kw>
-        <kw canonical="Flink">(?:Apache )?Flink</kw>
         <kw canonical="LangChain">LangChain</kw>
         <!-- OpenAI: case_sensitive matches the brand name precisely -->
         <kw canonical="OpenAI" case_sensitive="true">OpenAI</kw>
         <kw canonical="MLflow">MLflow</kw>
         <!-- Vector DB: matches named databases + plain-English descriptions -->
         <kw canonical="Vector DB">(?:Pinecone|Qdrant|Weaviate|Chroma|vector\s+(?:database|store|DB))</kw>
+        <kw canonical="Hugging Face">(?:Hugging\s+Face|HuggingFace)</kw>
+        <kw canonical="Weights &amp; Biases">Weights\s+(?:&amp;|and)\s+Biases</kw>
 
         <!-- Infrastructure / Cloud -->
         <kw canonical="AWS">AWS</kw>
         <kw canonical="GCP">GCP</kw>
         <kw canonical="Azure">Azure</kw>
+        <kw canonical="Vercel">Vercel</kw>
+        <kw canonical="DigitalOcean">DigitalOcean</kw>
+        <kw canonical="Heroku">Heroku</kw>
         <kw canonical="Kubernetes">Kubernetes</kw>
         <kw canonical="Docker">Docker</kw>
         <kw canonical="Terraform">Terraform</kw>
         <kw canonical="Ansible">Ansible</kw>
         <kw canonical="CI/CD">CI/CD</kw>
         <kw canonical="GitHub Actions">GitHub Actions</kw>
+        <kw canonical="GitLab CI">GitLab\s+CI(?:/CD)?</kw>
+        <kw canonical="CircleCI">CircleCI</kw>
         <kw canonical="Jenkins">Jenkins</kw>
         <kw canonical="Helm">Helm</kw>
         <!-- ArgoCD: Argo\s*CD matches "ArgoCD" (0 spaces) and "Argo CD" (1 space) -->
         <kw canonical="ArgoCD">Argo\s*CD</kw>
+        <kw canonical="Pulumi">Pulumi</kw>
         <kw canonical="Prometheus">Prometheus</kw>
         <kw canonical="Grafana">Grafana</kw>
         <kw canonical="Nginx">Nginx</kw>
         <kw canonical="Cloudflare">Cloudflare</kw>
+        <!-- Vault: case_sensitive avoids matching lowercase "vault" (common English noun) -->
+        <kw canonical="Vault" case_sensitive="true">(?:HashiCorp\s+)?Vault</kw>
 
         <!-- Databases -->
         <kw canonical="PostgreSQL">Postgres(?:QL)?</kw>
@@ -184,6 +206,10 @@
         <kw canonical="BigQuery">BigQuery</kw>
         <kw canonical="DynamoDB">DynamoDB</kw>
         <kw canonical="Cassandra">Cassandra</kw>
+        <kw canonical="ClickHouse">ClickHouse</kw>
+        <kw canonical="Firebase">Firebase</kw>
+        <kw canonical="Supabase">Supabase</kw>
+        <kw canonical="SQLite">SQLite</kw>
 
         <!-- Mobile -->
         <kw canonical="Android">Android</kw>
@@ -194,11 +220,27 @@
 
         <!-- Testing / QA -->
         <kw canonical="Jest">Jest</kw>
+        <kw canonical="Vitest">Vitest</kw>
         <kw canonical="Cypress">Cypress</kw>
         <kw canonical="Playwright">Playwright</kw>
         <kw canonical="Selenium">Selenium</kw>
         <kw canonical="JUnit">JUnit</kw>
+        <kw canonical="pytest">pytest</kw>
+        <kw canonical="Mocha">Mocha</kw>
+        <kw canonical="RSpec">RSpec</kw>
         <kw canonical="Postman">Postman</kw>
+
+        <!-- AI Concepts -->
+        <kw canonical="AI Agents">(?:AI\s+agents?|agentic(?:\s+AI)?|agents?\s+IA)</kw>
+        <kw canonical="Prompt Engineering">(?:prompt\s+engineering|ing[eé]nierie\s+(?:de\s+)?prompts?)</kw>
+        <kw canonical="Fine-tuning">(?:fine[-\s]?tuning|finetuning)</kw>
+        <kw canonical="Embeddings">(?:vector\s+)?embeddings</kw>
+        <kw canonical="Semantic Search">(?:semantic\s+search|recherche\s+s[eé]mantique)</kw>
+        <!-- NLP: case_sensitive for the acronym; second entry covers the full phrase -->
+        <kw canonical="NLP" case_sensitive="true">NLP</kw>
+        <kw canonical="NLP">(?:natural\s+language\s+processing|traitement\s+du\s+langage\s+naturel)</kw>
+        <kw canonical="Computer Vision">(?:computer\s+vision|vision\s+par\s+ordinateur)</kw>
+        <kw canonical="GenAI">(?:GenAI|generative\s+AI|IA\s+g[eé]n[eé]rative)</kw>
 
       </keywords>
     </field>

--- a/specs/lever/extraction.xml
+++ b/specs/lever/extraction.xml
@@ -111,6 +111,7 @@
         <kw canonical="Ruby">Ruby</kw>
         <kw canonical="PHP">PHP</kw>
         <kw canonical="Swift">Swift</kw>
+        <kw canonical="Dart">Dart</kw>
         <kw canonical="Elixir">Elixir</kw>
         <kw canonical="Erlang">Erlang</kw>
         <!-- R: explicit \b guards since it is a single letter; case_sensitive avoids
@@ -132,6 +133,11 @@
         <kw canonical="REST" case_sensitive="true">REST(?:ful)?</kw>
         <kw canonical="Tailwind">Tailwind(?:\s+CSS)?</kw>
         <kw canonical="Redux">Redux</kw>
+        <!-- Vite: case_sensitive avoids matching French "vite" (quickly) in bilingual postings -->
+        <kw canonical="Vite" case_sensitive="true">Vite</kw>
+        <kw canonical="tRPC" case_sensitive="true">tRPC</kw>
+        <kw canonical="Remix">Remix</kw>
+        <kw canonical="Storybook">Storybook</kw>
 
         <!-- Backend frameworks -->
         <kw canonical="Django">Django</kw>
@@ -147,6 +153,8 @@
         <kw canonical="Laravel">Laravel</kw>
         <kw canonical="ASP.NET">ASP\.NET</kw>
         <kw canonical=".NET">\.NET</kw>
+        <!-- Gin: case_sensitive avoids matching the common English noun -->
+        <kw canonical="Gin" case_sensitive="true">Gin</kw>
 
         <!-- Data / ML / AI -->
         <kw canonical="Spark">(?:Apache )?Spark</kw>
@@ -161,7 +169,7 @@
         <kw canonical="scikit-learn">scikit-learn</kw>
         <kw canonical="Databricks">Databricks</kw>
         <kw canonical="RabbitMQ">RabbitMQ</kw>
-        <!-- LLM/RAG: case_sensitive avoids "llm" as a lowercase abbreviation match -->
+        <!-- LLM/RAG: case_sensitive avoids "llm"/"rag" as lowercase abbreviations -->
         <kw canonical="LLM" case_sensitive="true">LLM</kw>
         <kw canonical="RAG" case_sensitive="true">RAG</kw>
         <kw canonical="LangChain">LangChain</kw>
@@ -170,25 +178,35 @@
         <kw canonical="MLflow">MLflow</kw>
         <!-- Vector DB: matches named databases + plain-English descriptions -->
         <kw canonical="Vector DB">(?:Pinecone|Qdrant|Weaviate|Chroma|vector\s+(?:database|store|DB))</kw>
+        <kw canonical="Hugging Face">(?:Hugging\s+Face|HuggingFace)</kw>
+        <kw canonical="Weights &amp; Biases">Weights\s+(?:&amp;|and)\s+Biases</kw>
 
         <!-- Infrastructure / Cloud -->
         <kw canonical="AWS">AWS</kw>
         <kw canonical="GCP">GCP</kw>
         <kw canonical="Azure">Azure</kw>
+        <kw canonical="Vercel">Vercel</kw>
+        <kw canonical="DigitalOcean">DigitalOcean</kw>
+        <kw canonical="Heroku">Heroku</kw>
         <kw canonical="Kubernetes">Kubernetes</kw>
         <kw canonical="Docker">Docker</kw>
         <kw canonical="Terraform">Terraform</kw>
         <kw canonical="Ansible">Ansible</kw>
         <kw canonical="CI/CD">CI/CD</kw>
         <kw canonical="GitHub Actions">GitHub Actions</kw>
+        <kw canonical="GitLab CI">GitLab\s+CI(?:/CD)?</kw>
+        <kw canonical="CircleCI">CircleCI</kw>
         <kw canonical="Jenkins">Jenkins</kw>
         <kw canonical="Helm">Helm</kw>
         <!-- ArgoCD: Argo\s*CD matches "ArgoCD" (0 spaces) and "Argo CD" (1 space) -->
         <kw canonical="ArgoCD">Argo\s*CD</kw>
+        <kw canonical="Pulumi">Pulumi</kw>
         <kw canonical="Prometheus">Prometheus</kw>
         <kw canonical="Grafana">Grafana</kw>
         <kw canonical="Nginx">Nginx</kw>
         <kw canonical="Cloudflare">Cloudflare</kw>
+        <!-- Vault: case_sensitive avoids matching lowercase "vault" (common English noun) -->
+        <kw canonical="Vault" case_sensitive="true">(?:HashiCorp\s+)?Vault</kw>
 
         <!-- Databases -->
         <kw canonical="PostgreSQL">Postgres(?:QL)?</kw>
@@ -201,6 +219,9 @@
         <kw canonical="DynamoDB">DynamoDB</kw>
         <kw canonical="Cassandra">Cassandra</kw>
         <kw canonical="ClickHouse">ClickHouse</kw>
+        <kw canonical="Firebase">Firebase</kw>
+        <kw canonical="Supabase">Supabase</kw>
+        <kw canonical="SQLite">SQLite</kw>
 
         <!-- Mobile -->
         <kw canonical="React Native">React Native</kw>
@@ -211,11 +232,27 @@
 
         <!-- Testing / QA -->
         <kw canonical="Jest">Jest</kw>
+        <kw canonical="Vitest">Vitest</kw>
         <kw canonical="Cypress">Cypress</kw>
         <kw canonical="Playwright">Playwright</kw>
         <kw canonical="Selenium">Selenium</kw>
         <kw canonical="JUnit">JUnit</kw>
+        <kw canonical="pytest">pytest</kw>
+        <kw canonical="Mocha">Mocha</kw>
+        <kw canonical="RSpec">RSpec</kw>
         <kw canonical="Postman">Postman</kw>
+
+        <!-- AI Concepts -->
+        <kw canonical="AI Agents">(?:AI\s+agents?|agentic(?:\s+AI)?|agents?\s+IA)</kw>
+        <kw canonical="Prompt Engineering">(?:prompt\s+engineering|ing[eé]nierie\s+(?:de\s+)?prompts?)</kw>
+        <kw canonical="Fine-tuning">(?:fine[-\s]?tuning|finetuning)</kw>
+        <kw canonical="Embeddings">(?:vector\s+)?embeddings</kw>
+        <kw canonical="Semantic Search">(?:semantic\s+search|recherche\s+s[eé]mantique)</kw>
+        <!-- NLP: case_sensitive for the acronym; second entry covers the full phrase -->
+        <kw canonical="NLP" case_sensitive="true">NLP</kw>
+        <kw canonical="NLP">(?:natural\s+language\s+processing|traitement\s+du\s+langage\s+naturel)</kw>
+        <kw canonical="Computer Vision">(?:computer\s+vision|vision\s+par\s+ordinateur)</kw>
+        <kw canonical="GenAI">(?:GenAI|generative\s+AI|IA\s+g[eé]n[eé]rative)</kw>
 
       </keywords>
     </field>

--- a/specs/workday/extraction.xml
+++ b/specs/workday/extraction.xml
@@ -106,6 +106,7 @@
         <kw canonical="Ruby">Ruby</kw>
         <kw canonical="PHP">PHP</kw>
         <kw canonical="Swift">Swift</kw>
+        <kw canonical="Dart">Dart</kw>
         <kw canonical="Elixir">Elixir</kw>
         <kw canonical="Erlang">Erlang</kw>
         <kw canonical="R" case_sensitive="true">\bR\b</kw>
@@ -123,6 +124,11 @@
         <kw canonical="REST" case_sensitive="true">REST(?:ful)?</kw>
         <kw canonical="Tailwind">Tailwind(?:\s+CSS)?</kw>
         <kw canonical="Redux">Redux</kw>
+        <!-- Vite: case_sensitive avoids matching French "vite" (quickly) in bilingual postings -->
+        <kw canonical="Vite" case_sensitive="true">Vite</kw>
+        <kw canonical="tRPC" case_sensitive="true">tRPC</kw>
+        <kw canonical="Remix">Remix</kw>
+        <kw canonical="Storybook">Storybook</kw>
 
         <!-- Backend frameworks -->
         <kw canonical="Django">Django</kw>
@@ -132,45 +138,61 @@
         <kw canonical="Spring Boot">Spring(?:\s+Boot)?</kw>
         <kw canonical="NestJS">NestJS</kw>
         <kw canonical="gRPC">gRPC</kw>
+        <kw canonical="Celery">Celery</kw>
         <kw canonical="Laravel">Laravel</kw>
         <kw canonical="ASP.NET">ASP\.NET</kw>
         <kw canonical=".NET">\.NET</kw>
+        <!-- Gin: case_sensitive avoids matching the common English noun -->
+        <kw canonical="Gin" case_sensitive="true">Gin</kw>
 
         <!-- Data / ML / AI -->
         <kw canonical="Spark">(?:Apache )?Spark</kw>
         <kw canonical="Kafka">(?:Apache )?Kafka</kw>
         <kw canonical="Airflow">(?:Apache )?Airflow</kw>
+        <kw canonical="Flink">(?:Apache )?Flink</kw>
         <kw canonical="dbt">dbt</kw>
         <kw canonical="Pandas">Pandas</kw>
         <kw canonical="NumPy">NumPy</kw>
         <kw canonical="PyTorch">PyTorch</kw>
         <kw canonical="TensorFlow">TensorFlow</kw>
         <kw canonical="scikit-learn">scikit-learn</kw>
+        <kw canonical="Databricks">Databricks</kw>
+        <kw canonical="RabbitMQ">RabbitMQ</kw>
         <kw canonical="LLM" case_sensitive="true">LLM</kw>
         <kw canonical="RAG" case_sensitive="true">RAG</kw>
-        <kw canonical="Flink">(?:Apache )?Flink</kw>
         <kw canonical="LangChain">LangChain</kw>
         <kw canonical="OpenAI" case_sensitive="true">OpenAI</kw>
         <kw canonical="MLflow">MLflow</kw>
+        <!-- Vector DB: matches named databases + plain-English descriptions -->
         <kw canonical="Vector DB">(?:Pinecone|Qdrant|Weaviate|Chroma|vector\s+(?:database|store|DB))</kw>
+        <kw canonical="Hugging Face">(?:Hugging\s+Face|HuggingFace)</kw>
+        <kw canonical="Weights &amp; Biases">Weights\s+(?:&amp;|and)\s+Biases</kw>
 
         <!-- Infrastructure / Cloud -->
         <kw canonical="AWS">AWS</kw>
         <kw canonical="GCP">GCP</kw>
         <kw canonical="Azure">Azure</kw>
+        <kw canonical="Vercel">Vercel</kw>
+        <kw canonical="DigitalOcean">DigitalOcean</kw>
+        <kw canonical="Heroku">Heroku</kw>
         <kw canonical="Kubernetes">Kubernetes</kw>
         <kw canonical="Docker">Docker</kw>
         <kw canonical="Terraform">Terraform</kw>
         <kw canonical="Ansible">Ansible</kw>
         <kw canonical="CI/CD">CI/CD</kw>
         <kw canonical="GitHub Actions">GitHub Actions</kw>
+        <kw canonical="GitLab CI">GitLab\s+CI(?:/CD)?</kw>
+        <kw canonical="CircleCI">CircleCI</kw>
         <kw canonical="Jenkins">Jenkins</kw>
         <kw canonical="Helm">Helm</kw>
         <kw canonical="ArgoCD">Argo\s*CD</kw>
+        <kw canonical="Pulumi">Pulumi</kw>
         <kw canonical="Prometheus">Prometheus</kw>
         <kw canonical="Grafana">Grafana</kw>
         <kw canonical="Nginx">Nginx</kw>
         <kw canonical="Cloudflare">Cloudflare</kw>
+        <!-- Vault: case_sensitive avoids matching lowercase "vault" (common English noun) -->
+        <kw canonical="Vault" case_sensitive="true">(?:HashiCorp\s+)?Vault</kw>
 
         <!-- Databases -->
         <kw canonical="PostgreSQL">Postgres(?:QL)?</kw>
@@ -182,6 +204,10 @@
         <kw canonical="BigQuery">BigQuery</kw>
         <kw canonical="DynamoDB">DynamoDB</kw>
         <kw canonical="Cassandra">Cassandra</kw>
+        <kw canonical="ClickHouse">ClickHouse</kw>
+        <kw canonical="Firebase">Firebase</kw>
+        <kw canonical="Supabase">Supabase</kw>
+        <kw canonical="SQLite">SQLite</kw>
 
         <!-- Mobile -->
         <kw canonical="Android">Android</kw>
@@ -192,11 +218,27 @@
 
         <!-- Testing / QA -->
         <kw canonical="Jest">Jest</kw>
+        <kw canonical="Vitest">Vitest</kw>
         <kw canonical="Cypress">Cypress</kw>
         <kw canonical="Playwright">Playwright</kw>
         <kw canonical="Selenium">Selenium</kw>
         <kw canonical="JUnit">JUnit</kw>
+        <kw canonical="pytest">pytest</kw>
+        <kw canonical="Mocha">Mocha</kw>
+        <kw canonical="RSpec">RSpec</kw>
         <kw canonical="Postman">Postman</kw>
+
+        <!-- AI Concepts -->
+        <kw canonical="AI Agents">(?:AI\s+agents?|agentic(?:\s+AI)?|agents?\s+IA)</kw>
+        <kw canonical="Prompt Engineering">(?:prompt\s+engineering|ing[eé]nierie\s+(?:de\s+)?prompts?)</kw>
+        <kw canonical="Fine-tuning">(?:fine[-\s]?tuning|finetuning)</kw>
+        <kw canonical="Embeddings">(?:vector\s+)?embeddings</kw>
+        <kw canonical="Semantic Search">(?:semantic\s+search|recherche\s+s[eé]mantique)</kw>
+        <!-- NLP: case_sensitive for the acronym; second entry covers the full phrase -->
+        <kw canonical="NLP" case_sensitive="true">NLP</kw>
+        <kw canonical="NLP">(?:natural\s+language\s+processing|traitement\s+du\s+langage\s+naturel)</kw>
+        <kw canonical="Computer Vision">(?:computer\s+vision|vision\s+par\s+ordinateur)</kw>
+        <kw canonical="GenAI">(?:GenAI|generative\s+AI|IA\s+g[eé]n[eé]rative)</kw>
 
       </keywords>
     </field>


### PR DESCRIPTION
## Summary

Implements #110 — reconciles `canonical_tech_stack.json` with what the extraction specs already detect, adds 43 new canonical entries, and syncs all three ATS specs (Greenhouse, Lever, Workday) to uniform coverage.

> **Note:** every change to `canonical_tech_stack.json` invalidates all stored `enriched_prompt_hash` values and triggers a full re-enrichment on the next Sunday run.

---

## Technologies added

### `languages` (+7)
`Ruby`, `PHP`, `Scala`, `Dart`, `R`, `Elixir`, `C++`

These were already extracted by all three specs but absent from canonical — this PR closes that gap and adds `Dart` (Flutter companion language) as the one net-new spec entry.

### `frontend` (+4)
`Vite`, `tRPC`, `Remix`, `Storybook`

`Vite` uses `case_sensitive="true"` to avoid matching the French adverb *vite* (quickly) in bilingual QC job postings.

### `backend` (+6)
`Rails`, `Laravel`, `Flask`, `ASP.NET`, `Celery`, `Gin`

`Rails`, `Laravel`, `Flask`, `ASP.NET` were already in specs but missing from canonical.  
`Celery` was in Lever only — added to Greenhouse and Workday.  
`Gin` uses `case_sensitive="true"` to avoid the common English noun.

### `databases` (+5)
`BigQuery`, `Cassandra`, `Firebase`, `Supabase`, `SQLite`

`BigQuery` and `Cassandra` were already in specs but missing from canonical.

### `cloud` (+3)
`Vercel`, `DigitalOcean`, `Heroku`

### `devops` (+4)
`GitLab CI`, `CircleCI`, `Pulumi`, `Vault`

`GitLab CI` requires the `CI` suffix to avoid matching bare GitLab source-control mentions.  
`Vault` uses `case_sensitive="true"` (pattern `(?:HashiCorp\s+)?Vault`) to avoid false positives on the lowercase common noun.

### `data_ai` (+6)
`NumPy`, `scikit-learn`, `Hugging Face`, `Flink`, `RabbitMQ`, `Weights & Biases`

`NumPy`, `scikit-learn`, `Flink` were already in specs but missing from canonical.  
`Databricks` and `RabbitMQ` were in Lever only — added to Greenhouse and Workday.  
`Hugging Face` matches both `Hugging Face` and `HuggingFace`.  
`Weights & Biases` matches `Weights & Biases` and `Weights and Biases` (no W&B — too ambiguous).

### `testing` (+4)
`Vitest`, `pytest`, `Mocha`, `RSpec`

### `ai_concepts` (+8)
`AI Agents`, `Prompt Engineering`, `Fine-tuning`, `Embeddings`, `Semantic Search`, `NLP`, `Computer Vision`, `GenAI`

All are purely conceptual (no tools/libraries). Bilingual patterns cover French equivalents.  
`NLP` uses two `<kw>` entries: `case_sensitive="true"` for the acronym, case-insensitive for the full phrase.  
`Embeddings` matches plural only (`embeddings`) — avoids the verb gerund *embedding*.

---

## Specs modified
All three ATS specs updated to identical coverage:
- `specs/greenhouse/extraction.xml`
- `specs/lever/extraction.xml`
- `specs/workday/extraction.xml`

Also back-filled Greenhouse and Workday with entries that were Lever-only: `Databricks`, `RabbitMQ`, `Celery`, `ClickHouse` (Workday only).

---

## Candidates NOT added — with justification

| Candidate | Decision |
|---|---|
| `Erlang` | Already extracted by all specs but not in issue's candidate list — left for a dedicated follow-up |
| `W&B` | Too short and ambiguous — `Weights & Biases` full form is used instead |
| `Machine Learning` / `Deep Learning` / `AI` | Too broad; no conservative pattern prevents high false-positive rate in general tech descriptions |
| `Dart` (as Flutter lang) | **Added** — specific enough in QC mobile postings |

---

## Verifications

```
pytest tests/test_lever_regression.py -v   → 21 passed
pytest                                      → 290 passed
```

Closes #110