### PR TITLE
feat(filter): multi-technology filtering with AND logic (#107)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -110,7 +110,10 @@ const fetchJobsCached = unstable_cache(
       .order("first_seen_at", { ascending: sort === "asc" })
       .range(from, to);
 
-    if (tech)      query = query.contains("tech_stack", [tech]);
+    if (tech) {
+      const techs = tech.split(",").map((t) => t.trim()).filter(Boolean);
+      query = query.contains("tech_stack", techs);
+    }
     if (source)    query = query.eq("source", source);
     if (seniority) query = query.eq("seniority", seniority);
     if (remote === "true")  query = query.eq("is_remote", true);
@@ -224,8 +227,13 @@ async function fetchContextualFacets(filters: SearchParams, stats: Stats): Promi
     };
   }
 
+  // RPC accepts one tech value — use first selected tech (v1 approximation for multi-select).
+  const firstTech = normalized.tech
+    ? normalized.tech.split(",").map((t) => t.trim()).filter(Boolean)[0] ?? ""
+    : "";
+
   return fetchContextualFacetsCached(
-    normalized.tech,
+    firstTech,
     normalized.source,
     normalized.remote,
     normalized.seniority,
@@ -259,7 +267,8 @@ export default async function Page({
 
   const totalPages = Math.ceil(total / PAGE_SIZE);
   const hasFilters = !!(filters.tech || filters.source || filters.remote || filters.seniority);
-  const activeFilterCount = [filters.tech, filters.source, filters.remote, filters.seniority].filter(Boolean).length;
+  const techCount = filters.tech ? filters.tech.split(",").map((t) => t.trim()).filter(Boolean).length : 0;
+  const activeFilterCount = techCount + [filters.source, filters.remote, filters.seniority].filter(Boolean).length;
 
   const currentSort = filters.sort === "asc" ? "asc" : "desc";
 

--- a/frontend/components/ActiveFilterChips.tsx
+++ b/frontend/components/ActiveFilterChips.tsx
@@ -37,7 +37,8 @@ export default function ActiveFilterChips() {
   const remote    = params.get("remote");
   const seniority = params.get("seniority");
 
-  if (tech)      chips.push({ key: "tech",      label: tech });
+  const techs = tech ? tech.split(",").map((t) => t.trim()).filter(Boolean) : [];
+  techs.forEach((t) => chips.push({ key: `tech:${t}`, label: t }));
   if (source)    chips.push({ key: "source",    label: source.charAt(0).toUpperCase() + source.slice(1) });
   if (remote)    chips.push({ key: "remote",    label: WORKPLACE_LABEL[remote] ?? remote });
   if (seniority) chips.push({ key: "seniority", label: SENIORITY_LABEL[seniority] ?? seniority });
@@ -46,7 +47,18 @@ export default function ActiveFilterChips() {
 
   function remove(key: string) {
     const next = new URLSearchParams(params.toString());
-    next.delete(key);
+    if (key.startsWith("tech:")) {
+      const techToRemove = key.slice(5);
+      const current = (next.get("tech") ?? "").split(",").map((t) => t.trim()).filter(Boolean);
+      const updated = current.filter((t) => t !== techToRemove);
+      if (updated.length === 0) {
+        next.delete("tech");
+      } else {
+        next.set("tech", updated.join(","));
+      }
+    } else {
+      next.delete(key);
+    }
     next.delete("page");
     startTransition(() => router.replace(`?${next.toString()}`));
   }

--- a/frontend/components/FilterSidebar.tsx
+++ b/frontend/components/FilterSidebar.tsx
@@ -144,11 +144,29 @@ export default function FilterSidebar({
     startTransition(() => router.replace(`?${next.toString()}`));
   }
 
+  function toggleTech(value: string) {
+    const next = new URLSearchParams(params.toString());
+    const current = (next.get("tech") ?? "").split(",").map((t) => t.trim()).filter(Boolean);
+    const idx = current.indexOf(value);
+    if (idx >= 0) {
+      current.splice(idx, 1);
+    } else {
+      current.push(value);
+    }
+    if (current.length === 0) {
+      next.delete("tech");
+    } else {
+      next.set("tech", current.join(","));
+    }
+    next.delete("page");
+    startTransition(() => router.replace(`?${next.toString()}`));
+  }
+
   function toggleSection(key: keyof typeof sections) {
     setSections((s) => ({ ...s, [key]: !s[key] }));
   }
 
-  const currentTech      = params.get("tech")      ?? "";
+  const currentTechs     = (params.get("tech") ?? "").split(",").map((t) => t.trim()).filter(Boolean);
   const currentSource    = params.get("source")    ?? "";
   const currentRemote    = params.get("remote")    ?? "";
   const currentSeniority = params.get("seniority") ?? "";
@@ -258,8 +276,8 @@ export default function FilterSidebar({
                 <FilterChip
                   key={t}
                   label={t}
-                  active={currentTech === t}
-                  onClick={() => toggle("tech", t)}
+                  active={currentTechs.includes(t)}
+                  onClick={() => toggleTech(t)}
                 />
               ))}
               {filteredTechs.length === 0 && (


### PR DESCRIPTION
## Summary

- Parses `?tech=React,TypeScript` as a comma-separated list and passes the full array to Supabase `.contains("tech_stack", techs)`, so only jobs containing **all** selected technologies are returned (AND semantics)
- `FilterSidebar` tech chips now toggle in/out of the active list instead of replacing it; non-tech filters (source, remote, seniority) remain single-select
- `ActiveFilterChips` renders one chip per selected technology; removing a chip drops only that tech from the URL param, deleting the param entirely when none remain
- `activeFilterCount` (mobile badge) counts each selected tech as +1 instead of the whole param as +1
- Contextual facet RPC receives only the first selected tech (v1 approximation — see issue #107 known limitation)

## Test plan

- [ ] `/` with no params behaves as before
- [ ] `/?tech=React` returns the same results as before
- [ ] `/?tech=React,TypeScript` returns only jobs whose `tech_stack` contains both values
- [ ] Clicking two tech chips updates the URL to `?tech=A,B` without losing source/remote/seniority params
- [ ] Removing one active tech chip removes only that tech; other filters and the remaining tech chips are preserved
- [ ] Removing the last tech chip deletes the `tech` param entirely
- [ ] Page resets to 1 whenever a tech filter changes
- [ ] Mobile filter badge shows the correct count (2 techs selected → badge shows 2, not 1)
- [ ] `npm run lint` passes
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)