### PR TITLE
fix(filter): replace type="search" with type="text" to fix missing left border

### DIFF
--- a/frontend/components/FilterSidebar.tsx
+++ b/frontend/components/FilterSidebar.tsx
@@ -258,7 +258,7 @@ export default function FilterSidebar({
         {sections.tech && (
           <div className="mt-1 flex flex-col gap-0.5">
             <input
-              type="search"
+              type="text"
               placeholder="Search tech…"
               value={techSearch}
               onChange={(e) => setTechSearch(e.target.value)}


### PR DESCRIPTION
## Summary

- `type="search"` causes Safari/iOS to apply native search-input styling (`-webkit-appearance: searchfield`) which clips or removes the left border of the input
- Switching to `type="text"` lets our custom `border` and `rounded-md` styles render consistently on all browsers

## Repro
Open the Technology filter section → focus the search box → left border of the input does not appear.

## Fix
One-line change: `type="search"` → `type="text"` in `FilterSidebar.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)