### PR TITLE
feat(cards): give company name a distinct secondary weight

### DIFF
--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -81,8 +81,8 @@ export default function JobCard({ job }: { job: Job }) {
           <LogoPlaceholder company={job.company} />
           <div className="min-w-0 flex-1">
             <p
-              className="truncate text-xs font-medium uppercase tracking-wide"
-              style={{ color: "var(--ink-mute)", fontFamily: "var(--font-mono)", fontSize: 10 }}
+              className="truncate text-xs font-semibold uppercase tracking-wide"
+              style={{ color: "var(--ink-soft)", fontFamily: "var(--font-mono)", fontSize: 11 }}
               title={job.company}
             >
               {job.company}


### PR DESCRIPTION
Title, company, and location/timestamp are meant to read as three visual tiers, but company name and the age/location metadata were both using --ink-mute at the same ~10px size — no distinction between "secondary" and "tertiary" despite the design system already defining a three-step scale (--ink / --ink-soft / --ink-mute) that this component just wasn't using in the middle.

Company name now uses --ink-soft, semibold, 11px — still visually subordinate to the title (--ink, 13.5px) but clearly a step above the location/age metadata (--ink-mute, 10-11px), keeping the existing mono/uppercase micro-label treatment used elsewhere in the app.

Refs #132