### PR TITLE
feat: saved alerts + highlight matching cards (#126, #133)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -10,6 +10,7 @@ import KpiStrip from "@/components/KpiStrip";
 import FilterSidebar from "@/components/FilterSidebar";
 import ActiveFilterChips from "@/components/ActiveFilterChips";
 import MobileFilterDrawer from "@/components/MobileFilterDrawer";
+import AlertRuleEditor from "@/components/AlertRuleEditor";
 
 export const metadata: Metadata = {
   title: "Tech Jobs in Montreal and Quebec",
@@ -324,19 +325,9 @@ export default async function Page({
         </Suspense>
 
         {/* Save-as-alert CTA */}
-        <div
-          className="mt-6 rounded-md px-3 py-3 text-xs"
-          style={{
-            border: "1.5px dashed var(--accent)",
-            color: "var(--accent)",
-            background: "var(--accent-12)",
-          }}
-        >
-          <p className="font-semibold" style={{ fontSize: 11 }}>★ Save as alert</p>
-          <p className="mt-0.5" style={{ color: "var(--ink-soft)", fontSize: 10 }}>
-            Get email notifications when new roles match this search.
-          </p>
-        </div>
+        <Suspense>
+          <AlertRuleEditor variant="sidebar-cta" />
+        </Suspense>
       </aside>
 
       {/* ── Main content ──────────────────────────────────────────────── */}

--- a/frontend/app/saved/SavedPageClient.tsx
+++ b/frontend/app/saved/SavedPageClient.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState, useSyncExternalStore } from "react";
+import { Suspense, useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { KanbanCard } from "@/components/KanbanCard";
 import type { SavedJob, Column } from "@/components/KanbanCard";
+import AlertRuleEditor from "@/components/AlertRuleEditor";
+import { useAlerts, removeAlert, toggleAlert, type AlertCadence } from "@/lib/alertsStore";
 
 /* ── Storage keys ─────────────────────────────────────────────────────── */
 const STORAGE_KEY = "jobs-radar-qc:saved";
@@ -111,6 +113,13 @@ function ageFromTs(ts: number): string {
   if (diff === 1) return "yesterday";
   return `${diff}d`;
 }
+
+/* ── Alert cadence labels ─────────────────────────────────────────────── */
+const CADENCE_LABEL: Record<AlertCadence, string> = {
+  instant: "Instant",
+  daily_09: "Daily · 09:00",
+  weekly_mon: "Weekly · Mon",
+};
 
 /* ── Column config ────────────────────────────────────────────────────── */
 const COLUMNS: Array<{ key: Column; label: string; color: string }> = [
@@ -363,6 +372,9 @@ export default function SavedPageClient() {
   const [draggingId, setDraggingId]   = useState<string | null>(null);
   const [dragOverCol, setDragOverCol] = useState<Column | null>(null);
 
+  /* Saved alerts (issue #126) — jobs-radar-qc:alerts, see lib/alertsStore.ts */
+  const alerts = useAlerts();
+
   /* ── Move + remove ──
    * Write directly to storage; persistSaved/persistView dispatch a custom
    * DOM event that notifies the useSyncExternalStore subscriber, which
@@ -447,12 +459,11 @@ export default function SavedPageClient() {
   ) as Record<Column, number>;
 
   /*
-   * Stats — computed synchronously from `saved` state, no useEffect.
+   * Stats — computed synchronously from `saved` / `alerts` state, no useEffect.
    *
-   * activeAlerts: placeholder 0 until issue #25 (AlertRuleEditor) ships.
    * lastMatchText: most recent savedAt timestamp → "today", "yesterday", "Nd".
    */
-  const activeAlerts: number = 0; /* placeholder: #25 not shipped */
+  const activeAlerts = alerts.filter((a) => a.enabled).length;
   const latestSavedAt  = saved.length
     ? Math.max(...saved.map((j) => j.savedAt))
     : null;
@@ -566,35 +577,10 @@ export default function SavedPageClient() {
               </button>
             </div>
 
-            {/*
-             * + Add alert — disabled placeholder until issue #25 ships.
-             *
-             * Shown always so the layout is stable; grayed via opacity.
-             * aria-disabled conveys the disabled state to screen readers
-             * without hiding the element. The native `disabled` attribute
-             * prevents click events.
-             */}
-            <button
-              type="button"
-              disabled
-              aria-label="Add alert — coming soon"
-              title="Alert rules — coming soon"
-              style={{
-                padding: "4px 14px",
-                fontSize: 12,
-                fontWeight: 500,
-                background: "var(--accent)",
-                color: "var(--on-accent)",
-                border: "none",
-                borderRadius: 6,
-                cursor: "not-allowed",
-                opacity: 0.45,
-                minHeight: 30,
-                whiteSpace: "nowrap",
-              }}
-            >
-              + Add alert
-            </button>
+            {/* + Add alert — opens the AlertRuleEditor modal (issue #126). */}
+            <Suspense>
+              <AlertRuleEditor variant="saved-button" />
+            </Suspense>
           </div>
         </div>
 
@@ -804,6 +790,96 @@ export default function SavedPageClient() {
           })}
         </div>
       )}
+
+      {/* ── Active alerts banner (issue #126) ────────────────────────────── */}
+      <section className="mt-8" aria-label="Active alerts">
+        <h2 style={{ fontSize: 13, fontWeight: 600, color: "var(--ink)", margin: "0 0 8px" }}>
+          Active alerts
+        </h2>
+        {alerts.length === 0 ? (
+          <p style={{ fontSize: 12, color: "var(--ink-mute)", margin: 0 }}>
+            No alerts yet — save a search from the homepage, or use &ldquo;+ Add alert&rdquo; above.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {alerts.map((alert) => (
+              <li
+                key={alert.id}
+                className="flex items-center gap-3 rounded-md px-3 py-2"
+                style={{
+                  border: "1px solid var(--rule-soft)",
+                  background: "var(--surface)",
+                  opacity: alert.enabled ? 1 : 0.5,
+                  transition: "opacity 120ms ease-out",
+                }}
+              >
+                <div className="min-w-0 flex-1">
+                  <p
+                    className="truncate"
+                    style={{ fontSize: 12.5, fontWeight: 500, color: "var(--ink)" }}
+                    title={alert.name}
+                  >
+                    {alert.name}
+                  </p>
+                  <p
+                    className="truncate"
+                    style={{ fontSize: 11, color: "var(--ink-mute)", fontFamily: "var(--font-mono)" }}
+                  >
+                    {CADENCE_LABEL[alert.cron]} · {alert.channel === "email" ? "Email" : "Slack"}: {alert.channelTarget}
+                  </p>
+                </div>
+
+                {alert.unreadCount > 0 && (
+                  <span
+                    className="shrink-0 rounded-full px-2 py-0.5"
+                    style={{ background: "var(--hilite-new)", color: "var(--ink)", fontSize: 10, fontWeight: 600 }}
+                  >
+                    +{alert.unreadCount} new
+                  </span>
+                )}
+
+                <button
+                  type="button"
+                  onClick={() => toggleAlert(alert.id)}
+                  aria-pressed={alert.enabled}
+                  aria-label={`${alert.enabled ? "Disable" : "Enable"} alert ${alert.name}`}
+                  className="shrink-0"
+                  style={{
+                    padding: "3px 10px",
+                    fontSize: 11,
+                    fontWeight: 500,
+                    color: alert.enabled ? "var(--on-accent)" : "var(--ink-soft)",
+                    background: alert.enabled ? "var(--accent)" : "var(--bg-2)",
+                    border: "1px solid " + (alert.enabled ? "var(--accent)" : "var(--rule-soft)"),
+                    borderRadius: 6,
+                    cursor: "pointer",
+                  }}
+                >
+                  {alert.enabled ? "On" : "Off"}
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => removeAlert(alert.id)}
+                  aria-label={`Delete alert ${alert.name}`}
+                  className="shrink-0"
+                  style={{
+                    padding: "3px 8px",
+                    fontSize: 12,
+                    color: "var(--ink-mute)",
+                    background: "transparent",
+                    border: "1px solid var(--rule-soft)",
+                    borderRadius: 6,
+                    cursor: "pointer",
+                  }}
+                >
+                  ×
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
     </main>
   );
 }

--- a/frontend/components/AlertMatchHighlight.tsx
+++ b/frontend/components/AlertMatchHighlight.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useAlerts, matchesAlert } from "@/lib/alertsStore";
+import type { Job } from "@/lib/types";
+
+function useAlertMatch(job: Job): boolean {
+  const alerts = useAlerts();
+  return alerts.some((a) => a.enabled && matchesAlert(job, a));
+}
+
+/**
+ * Full-card ring overlay when the job matches an enabled saved alert
+ * (issue #133 — Von Restorff effect). Absolute + pointer-events-none, so it
+ * never intercepts clicks or shifts layout. Renders nothing on no match.
+ */
+export function AlertMatchRing({ job }: { job: Job }) {
+  const matched = useAlertMatch(job);
+  if (!matched) return null;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 rounded-md"
+      style={{ boxShadow: "0 0 0 2px var(--hilite-new)" }}
+    />
+  );
+}
+
+/**
+ * Inline text badge for the job's chip row — flows with the other chips
+ * instead of floating over other controls (e.g. SaveButton). This is the
+ * non-color-alone signal; the ring above is the color signal.
+ */
+export function AlertMatchChip({ job }: { job: Job }) {
+  const matched = useAlertMatch(job);
+  if (!matched) return null;
+
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold"
+      style={{ background: "var(--hilite-new)", color: "var(--ink)", fontSize: 11 }}
+    >
+      Matches alert
+    </span>
+  );
+}

--- a/frontend/components/AlertRuleEditor.tsx
+++ b/frontend/components/AlertRuleEditor.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useSearchParams } from "next/navigation";
+import { addAlert, type AlertCadence, type AlertChannel } from "@/lib/alertsStore";
+
+const SENIORITY_LABEL: Record<string, string> = {
+  internship: "Intern",
+  junior: "Junior",
+  senior: "Senior",
+  lead: "Lead",
+  staff: "Staff",
+  principal: "Principal",
+  manager: "Manager",
+  director: "Director",
+};
+
+const WORKPLACE_LABEL: Record<string, string> = {
+  true: "Remote",
+  false: "On-site",
+  null: "Hybride / Non spécifié",
+};
+
+const CADENCE_OPTIONS: { value: AlertCadence; label: string }[] = [
+  { value: "instant", label: "Instant" },
+  { value: "daily_09", label: "Daily · 09:00" },
+  { value: "weekly_mon", label: "Weekly · Mon" },
+];
+
+function buildName(params: URLSearchParams): string {
+  const parts: string[] = [];
+  const seniority = params.get("seniority");
+  if (seniority && SENIORITY_LABEL[seniority]) parts.push(SENIORITY_LABEL[seniority]);
+  const tech = params.get("tech");
+  if (tech) parts.push(tech.split(",").map((t) => t.trim()).filter(Boolean).join("/"));
+  const remote = params.get("remote");
+  if (remote && WORKPLACE_LABEL[remote]) parts.push(WORKPLACE_LABEL[remote]);
+  return parts.length > 0 ? parts.join(" · ") : "All roles";
+}
+
+function buildSummary(params: URLSearchParams): string {
+  const bits: string[] = [];
+  const tech = params.get("tech");
+  if (tech) bits.push(`tech: ${tech.split(",").map((t) => t.trim()).join(", ")}`);
+  const seniority = params.get("seniority");
+  if (seniority && SENIORITY_LABEL[seniority]) bits.push(`seniority: ${SENIORITY_LABEL[seniority]}`);
+  const remote = params.get("remote");
+  if (remote && WORKPLACE_LABEL[remote]) bits.push(`workplace: ${WORKPLACE_LABEL[remote]}`);
+  const source = params.get("source");
+  if (source) bits.push(`source: ${source}`);
+  return bits.length > 0 ? bits.join(" · ") : "No active filters — matches all roles";
+}
+
+interface Props {
+  /**
+   * "sidebar-cta"  — homepage desktop sidebar dashed-box CTA
+   * "saved-button" — /saved "+ Add alert" pill button
+   */
+  variant: "sidebar-cta" | "saved-button";
+}
+
+export default function AlertRuleEditor({ variant }: Props) {
+  const searchParams = useSearchParams();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [cadence, setCadence] = useState<AlertCadence>("instant");
+  const [channel, setChannel] = useState<AlertChannel>("email");
+  const [target, setTarget] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  const query = searchParams.toString();
+  const summary = buildSummary(searchParams);
+
+  const openModal = useCallback(() => {
+    setName(buildName(searchParams));
+    setChannel("email");
+    setTarget("");
+    setError(null);
+    setOpen(true);
+  }, [searchParams]);
+
+  const closeModal = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (open) requestAnimationFrame(() => nameInputRef.current?.focus());
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeModal();
+      }
+    }
+    window.addEventListener("keydown", onKeydown);
+    return () => window.removeEventListener("keydown", onKeydown);
+  }, [open, closeModal]);
+
+  function handleSave() {
+    const trimmedName = name.trim();
+    const trimmedTarget = target.trim();
+
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
+    if (!trimmedTarget) {
+      setError(channel === "email" ? "Email address is required." : "Slack webhook URL is required.");
+      return;
+    }
+    if (channel === "email" && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedTarget)) {
+      setError("Enter a valid email address.");
+      return;
+    }
+    if (channel === "slack" && !/^https:\/\//.test(trimmedTarget)) {
+      setError("Slack webhook URL must start with https://");
+      return;
+    }
+
+    addAlert({
+      name: trimmedName,
+      query,
+      cron: cadence,
+      channel,
+      channelTarget: trimmedTarget,
+    });
+    setOpen(false);
+  }
+
+  return (
+    <>
+      {variant === "sidebar-cta" ? (
+        <button
+          type="button"
+          onClick={openModal}
+          className="mt-6 block w-full rounded-md px-3 py-3 text-left text-xs"
+          style={{
+            border: "1.5px dashed var(--accent)",
+            color: "var(--accent)",
+            background: "var(--accent-12)",
+            cursor: "pointer",
+          }}
+        >
+          <p className="font-semibold" style={{ fontSize: 11 }}>★ Save as alert</p>
+          <p className="mt-0.5" style={{ color: "var(--ink-soft)", fontSize: 10 }}>
+            Get notified when new roles match this search.
+          </p>
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={openModal}
+          style={{
+            padding: "4px 14px",
+            fontSize: 12,
+            fontWeight: 500,
+            background: "var(--accent)",
+            color: "var(--on-accent)",
+            border: "none",
+            borderRadius: 6,
+            cursor: "pointer",
+            minHeight: 30,
+            whiteSpace: "nowrap",
+          }}
+        >
+          + Add alert
+        </button>
+      )}
+
+      {open && createPortal(
+        <div
+          role="presentation"
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 9999,
+            background: "rgba(29, 27, 24, 0.45)",
+            backdropFilter: "blur(4px)",
+            WebkitBackdropFilter: "blur(4px)",
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "center",
+            paddingTop: "clamp(48px, 10vh, 120px)",
+            paddingLeft: 16,
+            paddingRight: 16,
+          }}
+          onClick={closeModal}
+        >
+          <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Save as alert"
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: "100%",
+              maxWidth: 420,
+              background: "var(--surface)",
+              border: "1px solid var(--rule-soft)",
+              borderRadius: 8,
+              boxShadow: "0 8px 32px rgba(29,27,24,0.18)",
+              padding: 20,
+            }}
+          >
+            <p style={{ fontSize: 15, fontWeight: 600, color: "var(--ink)", margin: 0 }}>
+              Save as alert
+            </p>
+            <p style={{ fontSize: 11, color: "var(--ink-mute)", marginTop: 4, marginBottom: 16 }}>
+              Get notified when new roles match this search.
+            </p>
+
+            {/* Name */}
+            <label style={{ display: "block", fontSize: 11, fontWeight: 600, color: "var(--ink-soft)", marginBottom: 4 }}>
+              Name
+              <input
+                ref={nameInputRef}
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                style={{
+                  display: "block",
+                  width: "100%",
+                  marginTop: 4,
+                  padding: "6px 8px",
+                  fontSize: 13,
+                  fontWeight: 400,
+                  color: "var(--ink)",
+                  background: "var(--bg-2)",
+                  border: "1px solid var(--rule-soft)",
+                  borderRadius: 6,
+                }}
+              />
+            </label>
+
+            {/* Query summary (read-only) */}
+            <p style={{ fontSize: 11, fontWeight: 600, color: "var(--ink-soft)", marginTop: 12, marginBottom: 4 }}>
+              Query
+            </p>
+            <p
+              style={{
+                fontSize: 11,
+                fontFamily: "var(--font-mono)",
+                color: "var(--ink-mute)",
+                background: "var(--bg-2)",
+                border: "1px solid var(--rule-soft)",
+                borderRadius: 6,
+                padding: "6px 8px",
+                margin: 0,
+              }}
+            >
+              {summary}
+            </p>
+
+            {/* Cadence */}
+            <p style={{ fontSize: 11, fontWeight: 600, color: "var(--ink-soft)", marginTop: 12, marginBottom: 4 }}>
+              Cadence
+            </p>
+            <div role="radiogroup" aria-label="Cadence" style={{ display: "flex", gap: 6 }}>
+              {CADENCE_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={cadence === opt.value}
+                  onClick={() => setCadence(opt.value)}
+                  style={{
+                    flex: 1,
+                    padding: "5px 8px",
+                    fontSize: 11,
+                    fontWeight: 500,
+                    color: cadence === opt.value ? "var(--on-accent)" : "var(--ink-soft)",
+                    background: cadence === opt.value ? "var(--accent)" : "var(--bg-2)",
+                    border: "1px solid " + (cadence === opt.value ? "var(--accent)" : "var(--rule-soft)"),
+                    borderRadius: 6,
+                    cursor: "pointer",
+                  }}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Delivery */}
+            <p style={{ fontSize: 11, fontWeight: 600, color: "var(--ink-soft)", marginTop: 12, marginBottom: 4 }}>
+              Delivery
+            </p>
+            <div role="radiogroup" aria-label="Delivery channel" style={{ display: "flex", gap: 6, marginBottom: 6 }}>
+              {(["email", "slack"] as AlertChannel[]).map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  role="radio"
+                  aria-checked={channel === c}
+                  onClick={() => setChannel(c)}
+                  style={{
+                    flex: 1,
+                    padding: "5px 8px",
+                    fontSize: 11,
+                    fontWeight: 500,
+                    color: channel === c ? "var(--on-accent)" : "var(--ink-soft)",
+                    background: channel === c ? "var(--accent)" : "var(--bg-2)",
+                    border: "1px solid " + (channel === c ? "var(--accent)" : "var(--rule-soft)"),
+                    borderRadius: 6,
+                    cursor: "pointer",
+                  }}
+                >
+                  {c === "email" ? "Email" : "Slack webhook"}
+                </button>
+              ))}
+            </div>
+            <input
+              type={channel === "email" ? "email" : "url"}
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+              placeholder={channel === "email" ? "you@example.com" : "https://hooks.slack.com/..."}
+              aria-label={channel === "email" ? "Email address" : "Slack webhook URL"}
+              style={{
+                display: "block",
+                width: "100%",
+                padding: "6px 8px",
+                fontSize: 13,
+                color: "var(--ink)",
+                background: "var(--bg-2)",
+                border: "1px solid var(--rule-soft)",
+                borderRadius: 6,
+              }}
+            />
+
+            {error && (
+              <p role="alert" style={{ fontSize: 11, color: "var(--warning)", marginTop: 10, marginBottom: 0 }}>
+                {error}
+              </p>
+            )}
+
+            {/* Actions */}
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 18 }}>
+              <button
+                type="button"
+                onClick={closeModal}
+                style={{
+                  padding: "6px 14px",
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: "var(--ink-soft)",
+                  background: "transparent",
+                  border: "1px solid var(--rule-soft)",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                style={{
+                  padding: "6px 14px",
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: "var(--on-accent)",
+                  background: "var(--accent)",
+                  border: "none",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                }}
+              >
+                Save alert
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -1,5 +1,6 @@
 import { Job } from "@/lib/types";
 import SaveButton from "./SaveButton";
+import { AlertMatchRing, AlertMatchChip } from "./AlertMatchHighlight";
 
 const SENIORITY_LABEL: Record<string, string> = {
   internship: "Intern",
@@ -66,7 +67,7 @@ export default function JobCard({ job }: { job: Job }) {
 
   return (
     <div
-      className="group flex flex-col rounded-md"
+      className="group relative flex flex-col rounded-md"
       style={{
         background: "var(--surface)",
         border: "1px solid var(--rule-soft)",
@@ -75,6 +76,7 @@ export default function JobCard({ job }: { job: Job }) {
         transition: "border-color 120ms ease-out, box-shadow 120ms ease-out",
       }}
     >
+      <AlertMatchRing job={job} />
       <div className="flex flex-col gap-2 p-4 pb-3">
         {/* ── Header: logo + company + location + age ── */}
         <div className="flex items-start gap-2">
@@ -162,6 +164,7 @@ export default function JobCard({ job }: { job: Job }) {
           >
             {remoteLabel(job.is_remote)}
           </span>
+          <AlertMatchChip job={job} />
         </div>
 
         {/* ── Tech chips ── */}

--- a/frontend/lib/alertsStore.ts
+++ b/frontend/lib/alertsStore.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import type { Job } from "@/lib/types";
+
+/* ── Types ─────────────────────────────────────────────────────────────── */
+export type AlertCadence = "instant" | "daily_09" | "weekly_mon";
+export type AlertChannel = "email" | "slack";
+
+export interface SavedFilter {
+  id: string;
+  name: string;
+  /** URLSearchParams string, e.g. "tech=Go,Python&seniority=senior" */
+  query: string;
+  cron: AlertCadence;
+  channel: AlertChannel;
+  channelTarget: string;
+  unreadCount: number;
+  enabled: boolean;
+}
+
+/* ── Storage keys ─────────────────────────────────────────────────────── */
+const STORAGE_KEY = "jobs-radar-qc:alerts";
+
+/*
+ * Custom DOM event used to notify useSyncExternalStore subscribers when
+ * localStorage changes within the same tab. The native "storage" event only
+ * fires for changes from other tabs — same convention as SaveButton.tsx /
+ * SavedPageClient.tsx.
+ */
+const ALERTS_CHANGE = "jobs-radar-qc:alerts-change";
+
+/** Stable empty array returned by getServerSnapshot for the alerts list. */
+const SERVER_ALERTS: SavedFilter[] = [];
+
+let _raw: string | null = null;
+let _cache: SavedFilter[] = [];
+
+/* ── localStorage helpers ─────────────────────────────────────────────── */
+function loadAlerts(): SavedFilter[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === _raw) return _cache; // stable ref — no re-render
+    _raw = raw;
+    _cache = raw ? (JSON.parse(raw) as SavedFilter[]) : [];
+    return _cache;
+  } catch {
+    _raw = null;
+    _cache = [];
+    return _cache;
+  }
+}
+
+function persistAlerts(next: SavedFilter[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    _raw = null; // force reparse on next read, including in this tab
+    window.dispatchEvent(new Event(ALERTS_CHANGE));
+  } catch {}
+}
+
+function subscribeAlerts(cb: () => void): () => void {
+  window.addEventListener(ALERTS_CHANGE, cb);
+  window.addEventListener("storage", cb);
+  return () => {
+    window.removeEventListener(ALERTS_CHANGE, cb);
+    window.removeEventListener("storage", cb);
+  };
+}
+
+function getServerAlerts(): SavedFilter[] {
+  return SERVER_ALERTS;
+}
+
+/* ── Public hook ──────────────────────────────────────────────────────── */
+export function useAlerts(): SavedFilter[] {
+  return useSyncExternalStore(subscribeAlerts, loadAlerts, getServerAlerts);
+}
+
+/* ── Mutators ─────────────────────────────────────────────────────────── */
+export function addAlert(input: Omit<SavedFilter, "id" | "unreadCount" | "enabled">): SavedFilter {
+  const alert: SavedFilter = {
+    ...input,
+    id: crypto.randomUUID(),
+    unreadCount: 0,
+    enabled: true,
+  };
+  persistAlerts([...loadAlerts(), alert]);
+  return alert;
+}
+
+export function removeAlert(id: string) {
+  persistAlerts(loadAlerts().filter((a) => a.id !== id));
+}
+
+export function toggleAlert(id: string) {
+  persistAlerts(loadAlerts().map((a) => (a.id === id ? { ...a, enabled: !a.enabled } : a)));
+}
+
+/* ── Matching ─────────────────────────────────────────────────────────────
+ * Compares a job against a saved alert's stored query string. Fields present
+ * in the query must ALL match (AND); a multi-value "tech" field matches if
+ * ANY listed tech is present on the job (OR) — mirroring how the tech filter
+ * itself narrows results elsewhere in the app.
+ * An empty query never matches, so a filterless alert doesn't light up every
+ * card.
+ * ─────────────────────────────────────────────────────────────────────── */
+export function matchesAlert(job: Job, alert: SavedFilter): boolean {
+  if (!alert.query) return false;
+  const params = new URLSearchParams(alert.query);
+
+  const tech = params.get("tech");
+  if (tech) {
+    const wanted = tech.split(",").map((t) => t.trim().toLowerCase()).filter(Boolean);
+    const has = job.tech_stack.some((t) => wanted.includes(t.toLowerCase()));
+    if (!has) return false;
+  }
+
+  const seniority = params.get("seniority");
+  if (seniority && job.seniority !== seniority) return false;
+
+  const source = params.get("source");
+  if (source && job.source !== source) return false;
+
+  const remote = params.get("remote");
+  if (remote) {
+    const wanted = remote === "true" ? true : remote === "false" ? false : null;
+    if (job.is_remote !== wanted) return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- Implements #126 — the saved-alerts system was in prod as a decorative CTA (homepage sidebar) and a disabled button (`/saved`), with no persistence or editor behind either. Adds a client-only `AlertRuleEditor` modal (name, cadence, email/Slack delivery) backed by `localStorage` (`jobs-radar-qc:alerts`), wired into both entry points, plus a new "Active alerts" banner on `/saved` (toggle, delete, unread pill) and a real `activeAlerts` count replacing the hardcoded `0`.
- Implements #133 (blocked on #126) — job cards matching an enabled alert get a ring + "Matches alert" badge (Von Restorff effect), isolated in a small client component so `JobCard` stays a Server Component. Non-matching cards are untouched.
- Sending real emails/Slack messages and server-side match computation are out of scope per #126's spec — delivery targets are stored but not acted upon (v1, client-only).

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Manual pass in a headless browser against the dev server: save an alert from a filtered homepage search → correct localStorage entry; on the unfiltered homepage only matching cards (3/30) get the ring+badge, others stay default
- [x] `/saved`: "+ Add alert" enabled, new alert appears in the Active alerts banner with correct cadence/channel, stats strip shows the right count
- [x] Toggle alert off → homepage highlight disappears; delete → banner and count update
- [x] Dark mode checked — `--hilite-new` token renders with good contrast
- [x] Zero console errors across the flow
- [ ] No test framework exists in `frontend/` (no Jest/Vitest) — verification was manual per the project's documented quality-check flow rather than introducing a new test dependency unilaterally

Closes #126, closes #133