### PR TITLE
feat(alerts): move "Save as alert" CTA next to the results header (#134)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -323,11 +323,6 @@ export default async function Page({
             workplaceCounts={workplaceCounts}
           />
         </Suspense>
-
-        {/* Save-as-alert CTA */}
-        <Suspense>
-          <AlertRuleEditor variant="sidebar-cta" />
-        </Suspense>
       </aside>
 
       {/* ── Main content ──────────────────────────────────────────────── */}
@@ -374,9 +369,14 @@ export default async function Page({
           </div>
         )}
 
-        {/* Results header */}
-        <div className="mb-3 flex items-center justify-between">
-          <div className="flex items-baseline gap-2">
+        {/* Results header — sticky below the fixed top nav (45px) so the
+         * count and "Save as alert" CTA stay visible while scrolling (#134).
+         * background matches the page so scrolling cards don't show through. */}
+        <div
+          className="sticky z-10 mb-3 flex flex-wrap items-center justify-between gap-2 py-2"
+          style={{ top: 45, background: "var(--bg)" }}
+        >
+          <div className="flex flex-wrap items-baseline gap-2">
             <h1
               className="text-sm font-semibold"
               style={{ color: "var(--ink)", fontSize: 13 }}
@@ -389,6 +389,9 @@ export default async function Page({
             >
               · {stats.companyCount} companies · updated daily
             </span>
+            <Suspense>
+              <AlertRuleEditor variant="results-header" />
+            </Suspense>
           </div>
           <a
             href={sortUrl()}

--- a/frontend/components/AlertRuleEditor.tsx
+++ b/frontend/components/AlertRuleEditor.tsx
@@ -54,10 +54,10 @@ function buildSummary(params: URLSearchParams): string {
 
 interface Props {
   /**
-   * "sidebar-cta"  — homepage desktop sidebar dashed-box CTA
-   * "saved-button" — /saved "+ Add alert" pill button
+   * "results-header" — homepage results-header inline CTA (issue #134)
+   * "saved-button"   — /saved "+ Add alert" pill button
    */
-  variant: "sidebar-cta" | "saved-button";
+  variant: "results-header" | "saved-button";
 }
 
 export default function AlertRuleEditor({ variant }: Props) {
@@ -136,22 +136,22 @@ export default function AlertRuleEditor({ variant }: Props) {
 
   return (
     <>
-      {variant === "sidebar-cta" ? (
+      {variant === "results-header" ? (
         <button
           type="button"
           onClick={openModal}
-          className="mt-6 block w-full rounded-md px-3 py-3 text-left text-xs"
+          title="Get notified when new roles match this search."
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors"
           style={{
-            border: "1.5px dashed var(--accent)",
+            border: "1px solid var(--accent)",
             color: "var(--accent)",
             background: "var(--accent-12)",
+            fontSize: 11,
+            fontWeight: 500,
             cursor: "pointer",
           }}
         >
-          <p className="font-semibold" style={{ fontSize: 11 }}>★ Save as alert</p>
-          <p className="mt-0.5" style={{ color: "var(--ink-soft)", fontSize: 10 }}>
-            Get notified when new roles match this search.
-          </p>
+          ★ Save as alert
         </button>
       ) : (
         <button


### PR DESCRIPTION
## Summary
- Relocates the "★ Save as alert" CTA from the sidebar (buried mid-filter-panel, disconnected from the results it acts on) to sit inline with the results count/header — "375 active roles · 42 companies · updated daily · ★ Save as alert" — per the acceptance criteria.
- Makes the results-header row `position: sticky` (docked below the fixed top nav) so the count and CTA stay visible while scrolling the job list, addressing the "remains sticky or visible on scroll if feasible" criterion.
- `AlertRuleEditor`'s `sidebar-cta` variant is renamed to `results-header` with compact inline styling (small pill button) instead of the old dashed sidebar box, since the sidebar location no longer has a use site.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Manual pass in a headless browser against the dev server: CTA confirmed removed from the sidebar, present exactly once next to the results header
- [x] Scrolled 1400px — header row + CTA remain pinned right below the top nav, no overlap/bleed-through from cards scrolling underneath
- [x] Modal still opens/saves correctly from the new location
- [x] Mobile viewport (390px) — row wraps cleanly, no overlap
- [x] Zero console errors

Closes #134