### PR TITLE
revert: undo #134 CTA relocation and full-width bar fix

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -323,6 +323,11 @@ export default async function Page({
             workplaceCounts={workplaceCounts}
           />
         </Suspense>
+
+        {/* Save-as-alert CTA */}
+        <Suspense>
+          <AlertRuleEditor variant="sidebar-cta" />
+        </Suspense>
       </aside>
 
       {/* ── Main content ──────────────────────────────────────────────── */}
@@ -369,14 +374,9 @@ export default async function Page({
           </div>
         )}
 
-        {/* Results header — sticky below the fixed top nav (45px) so the
-         * count and "Save as alert" CTA stay visible while scrolling (#134).
-         * background matches the page so scrolling cards don't show through. */}
-        <div
-          className="sticky z-10 mb-3 flex flex-wrap items-center justify-between gap-2 py-2"
-          style={{ top: 45, background: "var(--bg)" }}
-        >
-          <div className="flex flex-wrap items-baseline gap-2">
+        {/* Results header */}
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-baseline gap-2">
             <h1
               className="text-sm font-semibold"
               style={{ color: "var(--ink)", fontSize: 13 }}
@@ -389,9 +389,6 @@ export default async function Page({
             >
               · {stats.companyCount} companies · updated daily
             </span>
-            <Suspense>
-              <AlertRuleEditor variant="results-header" />
-            </Suspense>
           </div>
           <a
             href={sortUrl()}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -298,57 +298,7 @@ export default async function Page({
   }
 
   return (
-    <>
-      {/* ── Results toolbar — full-width sticky bar below the fixed top nav
-       * (45px). Lives outside <main> so its background spans edge-to-edge,
-       * including over the sidebar column: previously it was nested inside
-       * the content column only, so once stuck the sidebar's own sticky
-       * content (which sticks at a different offset) showed through beside
-       * it instead of scrolling underneath (#134 follow-up). */}
-      <div
-        className="sticky z-30 border-b"
-        style={{ top: 45, background: "var(--bg)", borderColor: "var(--rule-soft)" }}
-      >
-        <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-2 px-4 py-2">
-          <div className="flex flex-wrap items-baseline gap-2">
-            <h1
-              className="text-sm font-semibold"
-              style={{ color: "var(--ink)", fontSize: 13 }}
-            >
-              {hasFilters ? `${total} matching role${total !== 1 ? "s" : ""}` : `${total} active role${total !== 1 ? "s" : ""}`}
-            </h1>
-            <span
-              className="text-xs"
-              style={{ color: "var(--ink-mute)", fontFamily: "var(--font-mono)", fontSize: 10 }}
-            >
-              · {stats.companyCount} companies · updated daily
-            </span>
-            <Suspense>
-              <AlertRuleEditor variant="results-header" />
-            </Suspense>
-          </div>
-          <a
-            href={sortUrl()}
-            aria-label={
-              currentSort === "asc"
-                ? "↑ Date — sorted oldest first, click for newest first"
-                : "↓ Date — sorted newest first, click for oldest first"
-            }
-            title={currentSort === "asc" ? "Plus récents en premier" : "Plus anciens en premier"}
-            className="flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors"
-            style={{
-              border: "1px solid var(--rule-soft)",
-              color: "var(--ink-soft)",
-              fontFamily: "var(--font-mono)",
-              fontSize: 11,
-            }}
-          >
-            {currentSort === "asc" ? "↑" : "↓"} Date
-          </a>
-        </div>
-      </div>
-
-      <main className="mx-auto flex w-full max-w-7xl flex-1 px-4 py-6">
+    <main className="mx-auto flex w-full max-w-7xl flex-1 px-4 py-6">
       {/* ── Desktop sidebar ───────────────────────────────────────────── */}
       <aside
         className="hidden w-56 shrink-0 pr-6 lg:block sticky top-4 self-start max-h-[calc(100vh-2rem)] overflow-y-auto"
@@ -418,6 +368,50 @@ export default async function Page({
             </Suspense>
           </div>
         )}
+
+        {/* Results header — sticky below the fixed top nav (45px) so the
+         * count and "Save as alert" CTA stay visible while scrolling (#134).
+         * background matches the page so scrolling cards don't show through. */}
+        <div
+          className="sticky z-10 mb-3 flex flex-wrap items-center justify-between gap-2 py-2"
+          style={{ top: 45, background: "var(--bg)" }}
+        >
+          <div className="flex flex-wrap items-baseline gap-2">
+            <h1
+              className="text-sm font-semibold"
+              style={{ color: "var(--ink)", fontSize: 13 }}
+            >
+              {hasFilters ? `${total} matching role${total !== 1 ? "s" : ""}` : `${total} active role${total !== 1 ? "s" : ""}`}
+            </h1>
+            <span
+              className="text-xs"
+              style={{ color: "var(--ink-mute)", fontFamily: "var(--font-mono)", fontSize: 10 }}
+            >
+              · {stats.companyCount} companies · updated daily
+            </span>
+            <Suspense>
+              <AlertRuleEditor variant="results-header" />
+            </Suspense>
+          </div>
+          <a
+            href={sortUrl()}
+            aria-label={
+              currentSort === "asc"
+                ? "↑ Date — sorted oldest first, click for newest first"
+                : "↓ Date — sorted newest first, click for oldest first"
+            }
+            title={currentSort === "asc" ? "Plus récents en premier" : "Plus anciens en premier"}
+            className="flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors"
+            style={{
+              border: "1px solid var(--rule-soft)",
+              color: "var(--ink-soft)",
+              fontFamily: "var(--font-mono)",
+              fontSize: 11,
+            }}
+          >
+            {currentSort === "asc" ? "↑" : "↓"} Date
+          </a>
+        </div>
 
         {/* Jobs grid or empty state */}
         {jobs.length === 0 ? (
@@ -513,6 +507,5 @@ export default async function Page({
         )}
       </div>
     </main>
-    </>
   );
 }

--- a/frontend/components/AlertRuleEditor.tsx
+++ b/frontend/components/AlertRuleEditor.tsx
@@ -54,10 +54,10 @@ function buildSummary(params: URLSearchParams): string {
 
 interface Props {
   /**
-   * "results-header" — homepage results-header inline CTA (issue #134)
-   * "saved-button"   — /saved "+ Add alert" pill button
+   * "sidebar-cta"  — homepage desktop sidebar dashed-box CTA
+   * "saved-button" — /saved "+ Add alert" pill button
    */
-  variant: "results-header" | "saved-button";
+  variant: "sidebar-cta" | "saved-button";
 }
 
 export default function AlertRuleEditor({ variant }: Props) {
@@ -136,22 +136,22 @@ export default function AlertRuleEditor({ variant }: Props) {
 
   return (
     <>
-      {variant === "results-header" ? (
+      {variant === "sidebar-cta" ? (
         <button
           type="button"
           onClick={openModal}
-          title="Get notified when new roles match this search."
-          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors"
+          className="mt-6 block w-full rounded-md px-3 py-3 text-left text-xs"
           style={{
-            border: "1px solid var(--accent)",
+            border: "1.5px dashed var(--accent)",
             color: "var(--accent)",
             background: "var(--accent-12)",
-            fontSize: 11,
-            fontWeight: 500,
             cursor: "pointer",
           }}
         >
-          ★ Save as alert
+          <p className="font-semibold" style={{ fontSize: 11 }}>★ Save as alert</p>
+          <p className="mt-0.5" style={{ color: "var(--ink-soft)", fontSize: 10 }}>
+            Get notified when new roles match this search.
+          </p>
         </button>
       ) : (
         <button


### PR DESCRIPTION
## Summary
Reverts PR #151 (#134 — move "Save as alert" CTA to the results header) and PR #152 (its full-width sticky-bar follow-up fix), restoring `frontend/app/page.tsx` and `frontend/components/AlertRuleEditor.tsx` to exactly their state right after #150 merged.

Reported: even after #152's fix, the results bar still didn't look right in production once loaded — the sidebar `sticky` + full-width-bar combination has more problems than the follow-up fix accounted for. Rather than keep patching this in place, reverting the whole relocation back to the original sidebar CTA (from #126/#133) so the alerts feature stays in a known-good state while a proper fix for #134 is designed separately.

Verified this branch is byte-identical to `main` immediately after #150 (`git diff` against that commit is empty).

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] `git diff 688a11b HEAD` (the merge commit for #150) is empty — confirms exact restoration
- [ ] #134 will need to be re-attempted from scratch with a different approach

Note: #134 was previously closed by PR #151's merge; reopening it since this PR undoes that work.