### PR TITLE
polish(cards): consistent freshness granularity (#137)

### DIFF
--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -27,10 +27,13 @@ function remoteLabel(is_remote: boolean | null): string {
 
 function age(iso: string | null): { text: string; fresh: boolean } {
   if (!iso) return { text: "", fresh: false };
-  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000);
-  if (diff === 0) return { text: "today",     fresh: true };
-  if (diff === 1) return { text: "yesterday", fresh: true };
-  return               { text: `${diff}d`,   fresh: false };
+  const diffMs    = Date.now() - new Date(iso).getTime();
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays  = Math.floor(diffMs / 86_400_000);
+  const fresh     = diffDays <= 1;
+  if (diffHours < 1)  return { text: "just now",       fresh };
+  if (diffHours < 24) return { text: `${diffHours}h ago`, fresh };
+  return                     { text: `${diffDays}d ago`,  fresh };
 }
 
 /* Company logo placeholder — first 2 initials in a fixed-size box */


### PR DESCRIPTION
## Summary
- The KPI strip already showed hour-level precision ("Updated 14 hours ago", via `formatRelativeTime` in `KpiStrip.tsx`), but job cards only showed day-level ("today"/"yesterday"/"Nd") — the inconsistency called out in the issue.
- `JobCard.tsx`'s `age()` helper now shows "Xh ago" for postings <24h old and "Xd ago" beyond that, matching the issue's own examples ("2h ago", "1d ago") literally.
- The <48h "fresh" indicator (blue left border + dot) keeps the same threshold, just relabeled.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Verified live against the dev server: a 20h-old posting now shows "20h ago" (previously "today"), a 113d-old posting still shows "113d ago"
- [x] Checked dark + light mode — fresh accent styling unaffected
- [x] Zero console errors

Closes #137