### PR TITLE
polish(cards): hide workplace chip when unspecified (#138)

### DIFF
--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -19,10 +19,10 @@ const SOURCE_LABEL: Record<string, string> = {
   workable: "Workable",
 };
 
-function remoteLabel(is_remote: boolean | null): string {
+function remoteLabel(is_remote: boolean | null): string | null {
   if (is_remote === true)  return "Remote";
   if (is_remote === false) return "On-site";
-  return "Hybride / NS";
+  return null;
 }
 
 function age(iso: string | null): { text: string; fresh: boolean } {
@@ -155,18 +155,19 @@ export default function JobCard({ job }: { job: Job }) {
               {SENIORITY_LABEL[job.seniority]}
             </span>
           )}
-          <span
-            className="inline-flex items-center rounded-full px-2 py-0.5 text-xs"
-            style={{
-              background: "var(--bg-2)",
-              color: "var(--ink-soft)",
-              border: "1px solid var(--rule-soft)",
-              fontSize: 11,
-            }}
-            title={job.is_remote === null ? "Hybride ou sans information de localisation" : undefined}
-          >
-            {remoteLabel(job.is_remote)}
-          </span>
+          {remoteLabel(job.is_remote) && (
+            <span
+              className="inline-flex items-center rounded-full px-2 py-0.5 text-xs"
+              style={{
+                background: "var(--bg-2)",
+                color: "var(--ink-soft)",
+                border: "1px solid var(--rule-soft)",
+                fontSize: 11,
+              }}
+            >
+              {remoteLabel(job.is_remote)}
+            </span>
+          )}
           <AlertMatchChip job={job} />
         </div>
 


### PR DESCRIPTION
## Summary
- Jobs with `is_remote === null` showed a "Hybride / NS" chip on every card, conflating two different unknowns the schema can't actually distinguish (genuinely hybrid vs. no location info at all).
- `remoteLabel()` in `JobCard.tsx` now returns `null` for that case, and the chip is omitted entirely rather than showing a guess/placeholder — matching the acceptance criteria exactly.
- `Remote`/`On-site` chips are unaffected.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Verified live: "Hybride / NS" no longer appears anywhere on the homepage; "Remote"/"On-site" chips still render for jobs with known workplace type
- [x] Screenshot check — cards with no seniority and no workplace data render cleanly with an empty chip row (no visual gap/artifact)
- [x] Zero console errors

Closes #138