### PR TITLE
polish(cards): expandable tech-tag overflow with distinctive ordering (#139)

### DIFF
--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -1,6 +1,29 @@
 import { Job } from "@/lib/types";
 import SaveButton from "./SaveButton";
 import { AlertMatchRing, AlertMatchChip } from "./AlertMatchHighlight";
+import TechChips from "./TechChips";
+import { CANONICAL, buildTechToCatMap } from "@/lib/radarHelpers";
+
+const TECH_TO_CAT = buildTechToCatMap(CANONICAL);
+
+/**
+ * Category priority for surfacing "distinctive" tech tags first (issue
+ * #139) — cloud/devops infra (AWS, Docker, CI/CD, Terraform...) shows up on
+ * nearly every listing, so it's pushed toward the "+N" overflow in favor of
+ * languages, frameworks, and other tags that actually differentiate a role.
+ */
+const DISTINCTIVENESS_ORDER = [
+  "languages", "ai_concepts", "databases", "mobile", "frontend",
+  "backend", "data", "testing", "other", "devops", "cloud",
+];
+
+function sortByDistinctiveness(techs: string[]): string[] {
+  const rank = (t: string) => {
+    const idx = DISTINCTIVENESS_ORDER.indexOf(TECH_TO_CAT[t] ?? "other");
+    return idx === -1 ? DISTINCTIVENESS_ORDER.length : idx;
+  };
+  return [...techs].sort((a, b) => rank(a) - rank(b));
+}
 
 const SENIORITY_LABEL: Record<string, string> = {
   internship: "Intern",
@@ -172,32 +195,7 @@ export default function JobCard({ job }: { job: Job }) {
         </div>
 
         {/* ── Tech chips ── */}
-        {job.tech_stack.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {job.tech_stack.slice(0, CHIP_MAX).map((t) => (
-              <span
-                key={t}
-                className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium"
-                style={{
-                  background: "var(--bg-2)",
-                  color: "var(--ink-soft)",
-                  border: "1px solid var(--rule-soft)",
-                  fontSize: 11,
-                }}
-              >
-                {t}
-              </span>
-            ))}
-            {job.tech_stack.length > CHIP_MAX && (
-              <span
-                className="self-center text-xs"
-                style={{ color: "var(--ink-mute)", fontFamily: "var(--font-mono)", fontSize: 10 }}
-              >
-                +{job.tech_stack.length - CHIP_MAX}
-              </span>
-            )}
-          </div>
-        )}
+        <TechChips techs={sortByDistinctiveness(job.tech_stack)} max={CHIP_MAX} />
       </div>
 
       {/* ── Footer: view link ── */}

--- a/frontend/components/TechChips.tsx
+++ b/frontend/components/TechChips.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+
+const CHIP_STYLE = {
+  background: "var(--bg-2)",
+  color: "var(--ink-soft)",
+  border: "1px solid var(--rule-soft)",
+  fontSize: 11,
+};
+
+/**
+ * Tech-stack chip row with an expandable "+N" (issue #139) — previously a
+ * static, non-interactive label. `techs` should already be ordered with the
+ * most distinctive tags first (see sortByDistinctiveness in JobCard.tsx) so
+ * both the collapsed row and the "+N" hover preview lead with the most
+ * useful information.
+ */
+export default function TechChips({ techs, max }: { techs: string[]; max: number }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (techs.length === 0) return null;
+
+  const hiddenCount = techs.length - max;
+  const visible = expanded ? techs : techs.slice(0, max);
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {visible.map((t) => (
+        <span
+          key={t}
+          className="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium"
+          style={CHIP_STYLE}
+        >
+          {t}
+        </span>
+      ))}
+      {!expanded && hiddenCount > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          title={techs.slice(max).join(", ")}
+          aria-label={`Show ${hiddenCount} more technologies: ${techs.slice(max).join(", ")}`}
+          className="inline-flex items-center rounded px-1.5 py-0.5 text-xs transition-colors"
+          style={{ color: "var(--ink-mute)", fontFamily: "var(--font-mono)", fontSize: 10, cursor: "pointer" }}
+        >
+          +{hiddenCount}
+        </button>
+      )}
+      {expanded && hiddenCount > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          aria-label="Show fewer technologies"
+          className="inline-flex items-center rounded px-1.5 py-0.5 text-xs transition-colors"
+          style={{ color: "var(--ink-mute)", fontFamily: "var(--font-mono)", fontSize: 10, cursor: "pointer" }}
+        >
+          Show less
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- The "+N" tech-tag overflow (e.g. ".NET AWS Azure CI/CD +5") was a static, non-interactive label — not clickable or hoverable.
- New `TechChips` client component (JobCard stays a Server Component) makes "+N" a real button: click to expand and show all tags in place (with a "Show less" to collapse back), and a native `title` tooltip previewing the hidden tags on hover.
- Tags are now sorted by category distinctiveness before truncation, reusing the existing tech-category taxonomy (`lib/radarHelpers.ts`'s `CANONICAL`/`buildTechToCatMap`, already used by `FilterSidebar.tsx`): languages, AI/ML, databases, frontend/backend, data, testing surface first; generic cloud/devops infra (AWS, Docker, CI/CD, Terraform, Kubernetes, Azure, GCP...) that shows up on nearly every listing is pushed toward the overflow — addressing the issue's "consider showing the most distinctive tags" note.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Verified live: a card showing "C# Java Python TypeScript +5" hides exactly `CI/CD, Ansible, Kubernetes, Terraform, Azure` (confirmed via the hover title) — languages surfaced, generic infra collapsed
- [x] Click +5 -> expands to all 9 tags + "Show less"; click that -> collapses back to the original 4 + "+5", verified via DOM text content before/during/after
- [x] Checked dark/light and mobile — no layout issues
- [x] Zero console errors

Closes #139