### PR TITLE
polish(nav): active state for the current page (#140)

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import "./globals.css";
 import BottomTabBar from "@/components/BottomTabBar";
 import SearchPalette from "@/components/SearchPalette";
+import TopNavLinks from "@/components/TopNavLinks";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -80,34 +81,7 @@ export default function RootLayout({
             {/* Nav links + search */}
             <div className="flex items-center gap-4 lg:gap-5">
               {/* Main nav — hidden on mobile, BottomTabBar handles these routes */}
-              <Link
-                href="/"
-                className="hidden lg:inline text-sm transition-colors"
-                style={{ color: "var(--ink-soft)" }}
-              >
-                Jobs
-              </Link>
-              <Link
-                href="/trends"
-                className="hidden lg:inline text-sm transition-colors"
-                style={{ color: "var(--ink-soft)" }}
-              >
-                Radar
-              </Link>
-              <Link
-                href="/saved"
-                className="hidden lg:inline text-sm transition-colors"
-                style={{ color: "var(--ink-soft)" }}
-              >
-                Saved
-              </Link>
-              <Link
-                href="/about"
-                className="hidden lg:inline text-sm transition-colors"
-                style={{ color: "var(--ink-soft)" }}
-              >
-                About
-              </Link>
+              <TopNavLinks />
               <a
                 href="https://github.com/hippync/jobs-radar-qc"
                 target="_blank"

--- a/frontend/components/TopNavLinks.tsx
+++ b/frontend/components/TopNavLinks.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const LINKS = [
+  { href: "/", label: "Jobs" },
+  { href: "/trends", label: "Radar" },
+  { href: "/saved", label: "Saved" },
+  { href: "/about", label: "About" },
+];
+
+/**
+ * Desktop top-nav links with an active state for the current page (#140).
+ * Client component (needs usePathname) so the rest of the root layout can
+ * stay a Server Component — same isolation pattern as BottomTabBar, which
+ * already has its own active-state logic for the mobile equivalent.
+ */
+export default function TopNavLinks() {
+  const pathname = usePathname();
+
+  return (
+    <>
+      {LINKS.map(({ href, label }) => {
+        const active = pathname === href;
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? "page" : undefined}
+            className="hidden lg:inline text-sm transition-colors"
+            style={{
+              color: active ? "var(--accent)" : "var(--ink-soft)",
+              fontWeight: active ? 600 : 400,
+            }}
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- The desktop top nav (Jobs/Radar/Saved/About) had no visual distinction for the current page — plain static links. `BottomTabBar.tsx` already had this for mobile (color/weight/underline based on `usePathname()`), so this closes the gap on desktop only.
- New `TopNavLinks` client component (isolated via `usePathname()` so the root layout stays a Server Component, same pattern as `BottomTabBar`) applies accent color, bold weight, and `aria-current="page"` to whichever link matches the current route.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Verified live across all 4 routes (/, /trends, /saved, /about): exactly one link per page gets accent color + bold + `aria-current="page"`, matching the route
- [x] Screenshot check — active link reads clearly distinct from the others
- [x] Zero *new* console errors — noted a pre-existing hydration mismatch on `/trends` (floating-point `cx` rounding in `RadarChartClient`'s SVG) that reproduces identically on `main` without this change; unrelated to nav, out of scope here, worth its own issue

Closes #140