### PR TITLE
fix(cards): 375px horizontal overflow via grid min-width (#142)

### DIFF
--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -93,7 +93,7 @@ export default function JobCard({ job }: { job: Job }) {
 
   return (
     <div
-      className="group relative flex flex-col rounded-md"
+      className="group relative flex min-w-0 flex-col rounded-md"
       style={{
         background: "var(--surface)",
         border: "1px solid var(--rule-soft)",


### PR DESCRIPTION
## Summary
Audited job titles and tag lists at 375px per the acceptance criteria, across the homepage, `/trends`, `/saved` (board + list), `/about`, and the mobile filter drawer.

Found one real bug: `JobCard`'s outer div is a CSS grid item (child of `app/page.tsx`'s `grid gap-3 sm:grid-cols-2`) with no `min-width` set. Grid items default to `min-width: auto`, meaning unwrapped descendant content can force the item wider than its track — that's exactly what was happening: the company/location line and title text were pushing each card ~30px past its column, causing \~46px of page-level horizontal overflow (`scrollWidth` 421px vs. viewport 375px). Added `min-w-0` to the card root — the standard fix for this class of bug.

Everything else already wrapped correctly: card titles (`line-clamp-2`), Kanban cards on `/saved` (board + list, tested with a deliberately long title/company), `/about`'s prose and chip rows, and the mobile filter drawer. The horizontally-scrolling segment-filter strip on `/trends` is a deliberate `overflow-x-auto` pattern, not a bug — confirmed it doesn't contribute to page-level overflow.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Scoped `document.documentElement.scrollWidth` vs `window.innerWidth` check at 375px across 7 page/state combinations (homepage, homepage with an alert badge active, mobile filter drawer open, `/trends`, `/saved` board, `/saved` list, `/about`) — all now report zero overflow, down from 46px before the fix
- [x] Screenshot review of every page — titles wrap to 2 lines cleanly, long company/location text truncates with ellipsis, tech/source chip rows wrap without clipping
- [x] Zero *new* console errors — the same pre-existing `/trends` hydration mismatch noted in #140 reproduces here too, unrelated to this fix

Closes #142