### PR TITLE
feat: FR/EN language tag for job cards (#143)

### DIFF
--- a/frontend/components/JobCard.tsx
+++ b/frontend/components/JobCard.tsx
@@ -2,6 +2,7 @@ import { Job } from "@/lib/types";
 import SaveButton from "./SaveButton";
 import { AlertMatchRing, AlertMatchChip } from "./AlertMatchHighlight";
 import TechChips from "./TechChips";
+import { detectLanguage } from "@/lib/language";
 import { CANONICAL, buildTechToCatMap } from "@/lib/radarHelpers";
 
 const TECH_TO_CAT = buildTechToCatMap(CANONICAL);
@@ -90,6 +91,7 @@ function LogoPlaceholder({ company }: { company: string }) {
 export default function JobCard({ job }: { job: Job }) {
   const { text: ageText, fresh } = age(job.first_seen_at);
   const CHIP_MAX = 4;
+  const lang = detectLanguage(job.title);
 
   return (
     <div
@@ -189,6 +191,20 @@ export default function JobCard({ job }: { job: Job }) {
               }}
             >
               {remoteLabel(job.is_remote)}
+            </span>
+          )}
+          {lang && (
+            <span
+              className="inline-flex items-center rounded-full px-2 py-0.5 text-xs"
+              style={{
+                background: "var(--bg-2)",
+                color: "var(--ink-soft)",
+                border: "1px solid var(--rule-soft)",
+                fontSize: 11,
+              }}
+              title={lang === "fr" ? "Listing in French" : "Listing in English"}
+            >
+              {lang.toUpperCase()}
             </span>
           )}
           <AlertMatchChip job={job} />

--- a/frontend/lib/language.ts
+++ b/frontend/lib/language.ts
@@ -1,0 +1,43 @@
+export type JobLanguage = "fr" | "en";
+
+/**
+ * Lightweight, deterministic FR/EN classifier for job titles (issue #143).
+ *
+ * Frontend-only by design: the `active_qc_jobs` view the homepage queries
+ * doesn't expose job description text (only title, company, location,
+ * department, tech_stack, etc.), so this works from the title alone rather
+ * than requiring a Supabase migration. Accuracy is intentionally
+ * conservative — ambiguous or generic titles ("Manager", "Analyst", which
+ * appear untranslated in both French and English QC job postings) are left
+ * unclassified rather than guessed.
+ */
+
+const FRENCH_ACCENT_RE = /[àâäçéèêëîïôöûüùœ]/i;
+
+// Job-title words with no ambiguous French cognate risk (i.e. not commonly
+// borrowed into French postings, and spelled distinctly enough from their
+// French counterparts to avoid accidental matches — e.g. "technician" vs
+// "technicien").
+const EN_ONLY_WORDS = [
+  "engineer", "engineering", "developer", "specialist", "architect",
+  "consultant", "coordinator", "administrator", "representative",
+  "assistant", "associate", "officer", "scientist", "designer", "owner",
+  "technician", "recruiter", "accountant", "supervisor", "advisor", "clerk",
+];
+const EN_WORD_RE = new RegExp(`\\b(${EN_ONLY_WORDS.join("|")})\\b`, "i");
+
+// French job-title words that commonly appear without accents, spelled
+// distinctly enough from their English counterpart to avoid false matches
+// (e.g. "analyste" vs "analyst", "programmeur" vs "programmer").
+const FR_UNACCENTED_WORDS = [
+  "stagiaire", "adjoint", "adjointe", "analyste", "programmeur",
+  "programmeuse", "responsable", "gestionnaire",
+];
+const FR_WORD_RE = new RegExp(`\\b(${FR_UNACCENTED_WORDS.join("|")})\\b`, "i");
+
+export function detectLanguage(title: string): JobLanguage | null {
+  if (FRENCH_ACCENT_RE.test(title)) return "fr";
+  if (EN_WORD_RE.test(title)) return "en";
+  if (FR_WORD_RE.test(title)) return "fr";
+  return null;
+}


### PR DESCRIPTION
## Summary
Implements the tagging half of #143's acceptance criteria ("optional filter... **or** clearly tag each card's language").

**Scope decision, confirmed with the user first:** the `active_qc_jobs` view the homepage queries doesn't expose job description text (only title, company, location, department, tech_stack, etc.), so a true description-based classifier would require a Supabase migration — out of the frontend agent's default scope. Went with a title-only heuristic instead: no DB changes, no pipeline changes.

- `lib/language.ts` (new): deterministic `detectLanguage(title)` — French accented characters are a strong signal; a curated list of English-only and unaccented-French job-title words (spelled distinctly enough from their cross-language cognate to avoid false matches, e.g. "analyste" vs "analyst") as a fallback. Ambiguous/borrowed words used untranslated in both languages in QC postings ("Manager", "Analyst", "Expert") are deliberately left unclassified rather than guessed.
- `JobCard.tsx`: small "FR"/"EN" badge in the existing seniority/workplace chip row, styled identically to the other chips.

A real **filter** (not just a tag) would need either a DB-backed language column or fetching the full unpaginated result set to filter client-side (since language can't be pushed down into the Supabase query) — both felt out of proportion for this pass; noted as a natural follow-up if wanted.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Sampled ~120 real titles from the live dataset (4 pages) and manually reviewed every FR/EN classification — zero false positives spotted; iterated the word lists once based on real gaps found (e.g. "Analyste", "Responsable", "Gestionnaire", "Programmeur", "Engineering", "Supervisor", "Advisor", "Clerk"), improving labeled coverage from 62.5% to 75%
- [x] Screenshot check — badge styling matches existing chips, correctly absent on ambiguous titles ("Power Platform Expert", "Site Reliability Expert")
- [x] Zero console errors

Closes #143