### PR TITLE
polish: loading indicator for live stats during filter changes (#144)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -11,6 +11,8 @@ import FilterSidebar from "@/components/FilterSidebar";
 import ActiveFilterChips from "@/components/ActiveFilterChips";
 import MobileFilterDrawer from "@/components/MobileFilterDrawer";
 import AlertRuleEditor from "@/components/AlertRuleEditor";
+import { FilterTransitionProvider } from "@/components/FilterTransitionProvider";
+import KpiLoadingBar from "@/components/KpiLoadingBar";
 
 export const metadata: Metadata = {
   title: "Tech Jobs in Montreal and Quebec",
@@ -298,6 +300,7 @@ export default async function Page({
   }
 
   return (
+    <FilterTransitionProvider>
     <main className="mx-auto flex w-full max-w-7xl flex-1 px-4 py-6">
       {/* ── Desktop sidebar ───────────────────────────────────────────── */}
       <aside
@@ -333,7 +336,8 @@ export default async function Page({
       {/* ── Main content ──────────────────────────────────────────────── */}
       <div className="min-w-0 flex-1">
         {/* KPI strip */}
-        <div className="mb-5">
+        <div className="relative mb-5">
+          <KpiLoadingBar />
           <KpiStrip
             activeRoles={stats.companyCount > 0 ? total : 0}
             newToday={stats.newTodayCount}
@@ -518,5 +522,6 @@ export default async function Page({
         )}
       </div>
     </main>
+    </FilterTransitionProvider>
   );
 }

--- a/frontend/components/ActiveFilterChips.tsx
+++ b/frontend/components/ActiveFilterChips.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useTransition } from "react";
+import { useFilterTransition } from "./FilterTransitionProvider";
 
 const SENIORITY_LABEL: Record<string, string> = {
   internship: "Intern",
@@ -28,7 +28,7 @@ interface Chip {
 export default function ActiveFilterChips() {
   const router = useRouter();
   const params = useSearchParams();
-  const [isPending, startTransition] = useTransition();
+  const { isPending, startFilterTransition: startTransition } = useFilterTransition();
 
   const chips: Chip[] = [];
 

--- a/frontend/components/FilterSidebar.tsx
+++ b/frontend/components/FilterSidebar.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useRouter, useSearchParams } from "next/navigation";
-import { useTransition, useState } from "react";
+import { useState } from "react";
 import { ALL_CAT_SLUGS, CANONICAL, CATEGORY_LABELS, buildTechToCatMap } from "@/lib/radarHelpers";
+import { useFilterTransition } from "./FilterTransitionProvider";
 
 const OTHER_CAT = "other";
 const TECH_CAT_ORDER = [...ALL_CAT_SLUGS, OTHER_CAT];
@@ -136,7 +137,7 @@ export default function FilterSidebar({
 }: Props) {
   const router = useRouter();
   const params = useSearchParams();
-  const [isPending, startTransition] = useTransition();
+  const { isPending, startFilterTransition: startTransition } = useFilterTransition();
   const [techSearch, setTechSearch] = useState("");
 
   const [sections, setSections] = useState({

--- a/frontend/components/FilterTransitionProvider.tsx
+++ b/frontend/components/FilterTransitionProvider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, useContext, useTransition, type ReactNode, type TransitionStartFunction } from "react";
+
+interface FilterTransitionValue {
+  isPending: boolean;
+  startFilterTransition: TransitionStartFunction;
+}
+
+const FilterTransitionContext = createContext<FilterTransitionValue | null>(null);
+
+/**
+ * Shares one pending state across every control that can trigger a filter
+ * navigation (FilterSidebar, MobileFilterDrawer, ActiveFilterChips) so a
+ * single loading indicator (KpiLoadingBar) can react regardless of which
+ * control the user touched — each previously had its own local
+ * useTransition, visible only on that one control.
+ */
+export function FilterTransitionProvider({ children }: { children: ReactNode }) {
+  const [isPending, startFilterTransition] = useTransition();
+  return (
+    <FilterTransitionContext.Provider value={{ isPending, startFilterTransition }}>
+      {children}
+    </FilterTransitionContext.Provider>
+  );
+}
+
+export function useFilterTransition(): FilterTransitionValue {
+  const ctx = useContext(FilterTransitionContext);
+  if (!ctx) {
+    throw new Error("useFilterTransition must be used within a FilterTransitionProvider");
+  }
+  return ctx;
+}

--- a/frontend/components/KpiLoadingBar.tsx
+++ b/frontend/components/KpiLoadingBar.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useFilterTransition } from "./FilterTransitionProvider";
+
+/**
+ * Thin accent progress bar shown over the KPI strip while a filter
+ * navigation is pending (issue #144). Same visual language as
+ * RouteLoading's route-level indicator — no skeleton/pulsing placeholders,
+ * per agents/ux-ui_agent.md §7 ("No skeleton loaders... Never project a
+ * fake layout"). Renders nothing when idle.
+ */
+export default function KpiLoadingBar() {
+  const { isPending } = useFilterTransition();
+  if (!isPending) return null;
+
+  return (
+    <div
+      role="progressbar"
+      aria-label="Updating results"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 2,
+        overflow: "hidden",
+        background: "transparent",
+      }}
+    >
+      <div
+        aria-hidden="true"
+        className="route-progress-fill"
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          height: "100%",
+          width: "40%",
+          background: "var(--accent)",
+          borderRadius: 1,
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
**Design conflict found and resolved with the user before implementing:** #144 literally asks for a loading skeleton, but `agents/ux-ui_agent.md` §7 explicitly forbids skeleton loaders / fake layouts ("pulsing cards, ghost columns, etc.") and mandates a thin accent progress-bar pattern instead — already built as `RouteLoading`, used by every `loading.tsx`. Went with the style guide.

The actual gap: filter changes go through `startTransition` (by design, so the UI doesn't blank-flash), which means the OLD KPI numbers stay visible — stale, not blank — until the new data resolves. `FilterSidebar` and `ActiveFilterChips` each had their own local `useTransition`, so only the one control the user touched showed any pending feedback (a subtle opacity dim); the KPI strip itself gave no signal at all that it was about to change.

- `FilterTransitionProvider` (new): shares one `isPending` state across every filter-triggering control (`FilterSidebar` — also covers `MobileFilterDrawer`, which renders it — and `ActiveFilterChips`), replacing their independent local transitions.
- `KpiLoadingBar` (new): renders the same thin `--accent` progress-bar markup as `RouteLoading` over the KPI strip while any filter navigation is pending. Renders nothing when idle — no skeleton, no layout shift.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Verified live with network throttled (700ms) to make the pending window observable: progress bar absent when idle, present for the full duration of a filter click's transition, gone once the new numbers land
- [x] Screenshot check — thin bar visible mid-transition, clean settled state afterward with updated KPI numbers and active-filter chip
- [x] Zero console errors

Closes #144