### PR TITLE
polish(filters): collapse less-common seniority levels (#145)

### DIFF
--- a/frontend/components/FilterSidebar.tsx
+++ b/frontend/components/FilterSidebar.tsx
@@ -17,11 +17,14 @@ function techCatLabel(cat: string): string {
   return CATEGORY_LABELS[cat as keyof typeof CATEGORY_LABELS] ?? "Other";
 }
 
-const SENIORITY_OPTIONS = [
+const SENIORITY_DEFAULT = [
   { value: "internship", label: "Intern" },
   { value: "junior",     label: "Junior" },
   { value: "senior",     label: "Senior" },
   { value: "lead",       label: "Lead" },
+];
+
+const SENIORITY_MORE = [
   { value: "staff",      label: "Staff" },
   { value: "principal",  label: "Principal" },
   { value: "manager",    label: "Manager" },
@@ -151,6 +154,13 @@ export default function FilterSidebar({
     advanced:  params.has("source"),
   });
 
+  /* Off by default — 8 flat seniority levels was too much (#145). Except
+   * when the active filter is already one of the collapsed levels (e.g. a
+   * shared link), so it isn't hidden from where the user could change it. */
+  const [seniorityExpanded, setSeniorityExpanded] = useState(
+    () => SENIORITY_MORE.some((o) => o.value === params.get("seniority")),
+  );
+
   const initialTechs = (params.get("tech") ?? "").split(",").map((t) => t.trim()).filter(Boolean);
   const [techCatOpen, setTechCatOpen] = useState<Record<string, boolean>>(() => {
     const activeCats = new Set(initialTechs.map(techCategory));
@@ -245,7 +255,7 @@ export default function FilterSidebar({
         />
         {sections.seniority && (
           <div className="mt-1 flex flex-col gap-0.5">
-            {SENIORITY_OPTIONS.filter((o) => (seniorityCounts[o.value] ?? 0) > 0).map((opt) => (
+            {SENIORITY_DEFAULT.filter((o) => (seniorityCounts[o.value] ?? 0) > 0).map((opt) => (
               <FilterChip
                 key={opt.value}
                 label={opt.label}
@@ -254,6 +264,25 @@ export default function FilterSidebar({
                 onClick={() => toggle("seniority", opt.value)}
               />
             ))}
+            {seniorityExpanded &&
+              SENIORITY_MORE.filter((o) => (seniorityCounts[o.value] ?? 0) > 0).map((opt) => (
+                <FilterChip
+                  key={opt.value}
+                  label={opt.label}
+                  count={seniorityCounts[opt.value]}
+                  active={currentSeniority === opt.value}
+                  onClick={() => toggle("seniority", opt.value)}
+                />
+              ))}
+            <button
+              type="button"
+              onClick={() => setSeniorityExpanded((v) => !v)}
+              aria-expanded={seniorityExpanded}
+              className="mt-0.5 self-start px-2.5 text-xs transition-colors"
+              style={{ color: "var(--ink-mute)", fontSize: 11 }}
+            >
+              {seniorityExpanded ? "Show fewer" : "More levels"}
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- 8 flat seniority filter options (Intern → Director) was a lot for the sidebar.
- Intern/Junior/Senior/Lead now show by default; Staff/Principal/Manager/Director collapse under a "More levels" toggle ("Show fewer" to collapse back).
- Auto-expands when a collapsed-tier filter is already active via URL (e.g. `?seniority=director`, a shared link), so it isn't hidden from where the user could change it — same pattern as #141's Advanced/Source section.
- `MobileFilterDrawer` gets this for free since it reuses `FilterSidebar`.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Verified live via scoped DOM queries: exactly 4 chips (Intern/Junior/Senior/Lead) visible by default, "Staff" absent; after clicking "More levels" all 8 visible, "Staff" present; "Show fewer" collapses back to 4
- [x] Verified auto-expand: `?seniority=director` shows "Director" pre-expanded
- [x] Screenshot check — clean in both states
- [x] Zero console errors

Closes #145