### PR TITLE
feat(alerts): move "Save as alert" CTA next to the results header (#134)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -326,11 +326,6 @@ export default async function Page({
             workplaceCounts={workplaceCounts}
           />
         </Suspense>
-
-        {/* Save-as-alert CTA */}
-        <Suspense>
-          <AlertRuleEditor variant="sidebar-cta" />
-        </Suspense>
       </aside>
 
       {/* ── Main content ──────────────────────────────────────────────── */}
@@ -379,8 +374,8 @@ export default async function Page({
         )}
 
         {/* Results header */}
-        <div className="mb-3 flex items-center justify-between">
-          <div className="flex items-baseline gap-2">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-baseline gap-2">
             <h1
               className="text-sm font-semibold"
               style={{ color: "var(--ink)", fontSize: 13 }}
@@ -393,6 +388,9 @@ export default async function Page({
             >
               · {stats.companyCount} companies · updated daily
             </span>
+            <Suspense>
+              <AlertRuleEditor variant="results-header" />
+            </Suspense>
           </div>
           <a
             href={sortUrl()}

--- a/frontend/components/AlertRuleEditor.tsx
+++ b/frontend/components/AlertRuleEditor.tsx
@@ -54,10 +54,10 @@ function buildSummary(params: URLSearchParams): string {
 
 interface Props {
   /**
-   * "sidebar-cta"  — homepage desktop sidebar dashed-box CTA
-   * "saved-button" — /saved "+ Add alert" pill button
+   * "results-header" — homepage results-header inline CTA (issue #134)
+   * "saved-button"   — /saved "+ Add alert" pill button
    */
-  variant: "sidebar-cta" | "saved-button";
+  variant: "results-header" | "saved-button";
 }
 
 export default function AlertRuleEditor({ variant }: Props) {
@@ -136,22 +136,22 @@ export default function AlertRuleEditor({ variant }: Props) {
 
   return (
     <>
-      {variant === "sidebar-cta" ? (
+      {variant === "results-header" ? (
         <button
           type="button"
           onClick={openModal}
-          className="mt-6 block w-full rounded-md px-3 py-3 text-left text-xs"
+          title="Get notified when new roles match this search."
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs transition-colors"
           style={{
-            border: "1.5px dashed var(--accent)",
+            border: "1px solid var(--accent)",
             color: "var(--accent)",
             background: "var(--accent-12)",
+            fontSize: 11,
+            fontWeight: 500,
             cursor: "pointer",
           }}
         >
-          <p className="font-semibold" style={{ fontSize: 11 }}>★ Save as alert</p>
-          <p className="mt-0.5" style={{ color: "var(--ink-soft)", fontSize: 10 }}>
-            Get notified when new roles match this search.
-          </p>
+          ★ Save as alert
         </button>
       ) : (
         <button


### PR DESCRIPTION
## Summary
- Relocates the "★ Save as alert" CTA from the sidebar filter panel (buried mid-panel, disconnected from the results it acts on) to sit inline with the results-count header — "394 active roles · 42 companies · updated daily · ★ Save as alert" — addressing the primary acceptance criterion of #134.
- `AlertRuleEditor`'s `sidebar-cta` variant is renamed to `results-header` with compact inline pill styling, replacing the old dashed sidebar box.
- Deliberately **non-sticky**. Both prior attempts at this issue (#151, then its follow-up fix #152) made the results-header row sticky and broke visually in production in a way that wasn't reproducible locally — the row's own sticky offset (45px, below the fixed top nav) collided with the sidebar's independent `sticky; top: 16px` positioning and separate stacking context, so at ~1024–1170px widths the sidebar's own content showed through/beside the bar. Both were reverted in #153. This PR skips stickiness entirely, which removes that whole failure class structurally rather than patching around it again. The acceptance criterion ("remains sticky or visible on scroll if feasible") is treated as not feasible given this layout's constraints — happy to revisit as a separate, carefully-scoped follow-up if wanted.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] Playwright headless-browser check across 390/1024/1170/1440px, light + dark: exactly one CTA present, no other element overlapping it, zero console errors, and the "Save as alert" modal opens/closes correctly from the new location at every combination
- [x] Confirmed sidebar no longer renders the old dashed CTA box, and no remaining code references the removed `sidebar-cta` variant

Given last time's bug only surfaced in the deployed preview and not locally, **please check the Vercel preview for this PR yourself before merging** — don't take local verification alone as sufficient sign-off for this issue.

Closes #134