### PR TITLE
fix: repair debug_extraction.py and correct segment_rules.py doc claim (#127)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,8 @@ The engine (`pipeline/extractor.py`) is generic. **Adding a company = edit `sche
 
 Jobs on `/trends` can be filtered by market archetype. Classification is computed at query time from `tech_stack` — no DB column, no LLM call.
 
-Rules live in two files that **must be kept in sync**:
-- `core/segment_rules.py` — Python; classification actually runs only in `segmentHelpers.ts`, this module has no production caller and exists solely as the test-enforced spec `test_segmentation.py` pins the TS implementation against
+Rules live in two files that **must be kept in sync manually — nothing enforces it**:
+- `core/segment_rules.py` — Python; classification actually runs only in `segmentHelpers.ts`, this module has no production caller. `tests/test_segmentation.py` exercises `segment_rules.py` only — it does not cross-check `segmentHelpers.ts`, so there's no automated guard against the two drifting apart
 - `frontend/lib/segmentHelpers.ts` — TypeScript (used by the Next.js frontend)
 
 Priority order (first match wins):

--- a/scripts/debug_extraction.py
+++ b/scripts/debug_extraction.py
@@ -228,8 +228,7 @@ def main() -> None:
     print(f"ID:      {raw_id}")
 
     root = _load_spec(source)
-    spec_version = root.get("version", "?")
-    print(f"Spec:    specs/{source}/extraction.xml  version={spec_version}")
+    print(f"Spec:    specs/{source}/extraction.xml")
 
     job_data = _build_job_data(root, raw)
     records = _debug_keywords(root, job_data)


### PR DESCRIPTION
## Summary
A code review of the merged #127 dead-code sweep (PRs #165–168) surfaced 2 real regressions from that work — both confirmed by re-checking the actual code, not just re-reading the original issue.

1. **`scripts/debug_extraction.py:231`** read `root.get("version", "?")` to print each spec's version in its debug output. PR #167 dropped the `version` attribute from every `<extraction>` root element as dead config — accurately, the engine never parsed it — but missed this live consumer. The tool now always prints `version=?` for every ATS. Re-adding the attribute would reverse the already-agreed "drop, don't wire up" call for #167, so the fix removes the now-meaningless version display instead.

2. **`CLAUDE.md`**'s #168 doc correction for `core/segment_rules.py` claimed `tests/test_segmentation.py` "pins the TS implementation against" `segmentHelpers.ts`. Checked: that test file only imports `core.segment_rules` and never touches `segmentHelpers.ts` — there's no `*.test.ts` file anywhere in the repo. Reworded to state the actual, less reassuring truth: the two files must be kept in sync **manually**, with nothing automated guarding against drift.

## Test plan
- [x] `pytest` — 337 passed
- [x] `ruff check scripts/debug_extraction.py` — clean
- [x] `grep`-verified no other consumers were missed across all 4 categories of dropped config from #167 (nullable, schema.json keys, extraction root attrs)